### PR TITLE
Add support for call template data. Addresses #20.

### DIFF
--- a/call_template_data.go
+++ b/call_template_data.go
@@ -34,29 +34,23 @@ func newCallTemplateData(mtd *desc.MethodDescriptor, reqNum int64) *callTemplate
 }
 
 func (td *callTemplateData) execute(data string) (*bytes.Buffer, error) {
-	var err error
-
-	t := template.New("call_template_data")
-	t, err = t.Parse(data)
-	if err != nil {
-		return nil, err
-	}
+	t := template.Must(template.New("call_template_data").Parse(data))
 
 	var tpl bytes.Buffer
-	err = t.Execute(&tpl, td)
+	err := t.Execute(&tpl, td)
 	return &tpl, err
 }
 
 func (td *callTemplateData) executeData(data string) (interface{}, error) {
 
-	var tpl *bytes.Buffer
-	var err error
-	if tpl, err = td.execute(data); err != nil {
-		return nil, err
+	input := []byte(data)
+	tpl, err := td.execute(data)
+	if err == nil {
+		input = tpl.Bytes()
 	}
 
 	var dataMap interface{}
-	err = json.Unmarshal(tpl.Bytes(), &dataMap)
+	err = json.Unmarshal(input, &dataMap)
 	if err != nil {
 		return nil, err
 	}
@@ -65,14 +59,14 @@ func (td *callTemplateData) executeData(data string) (interface{}, error) {
 }
 
 func (td *callTemplateData) executeMetadata(metadata string) (*map[string]string, error) {
-	var tpl *bytes.Buffer
-	var err error
-	if tpl, err = td.execute(metadata); err != nil {
-		return nil, err
+	input := []byte(metadata)
+	tpl, err := td.execute(metadata)
+	if err == nil {
+		input = tpl.Bytes()
 	}
 
 	var mdMap map[string]string
-	err = json.Unmarshal(tpl.Bytes(), &mdMap)
+	err = json.Unmarshal(input, &mdMap)
 	if err != nil {
 		return nil, err
 	}

--- a/call_template_data.go
+++ b/call_template_data.go
@@ -4,23 +4,28 @@ import (
 	"bytes"
 	"encoding/json"
 	"text/template"
+	"time"
 
 	"github.com/jhump/protoreflect/desc"
 )
 
+// call template data
 type callTemplateData struct {
-	RequestNumber      int64
-	FullyQualifiedName string
-	MethodName         string
-	ServiceName        string
-	InputName          string
-	OutputName         string
-	IsClientStreaming  bool
-	IsServerStreaming  bool
+	RequestNumber      int64  // unique request number for each request
+	FullyQualifiedName string // fully-qualified name of the method call
+	MethodName         string // shorter call method name
+	ServiceName        string // the service name
+	InputName          string // name of the input message type
+	OutputName         string // name of the output message type
+	IsClientStreaming  bool   // whether this call is client streaming
+	IsServerStreaming  bool   // whether this call is server streaming
+	Timestamp          string // timestamp of the call in RFC3339 format
+	TimestampUnix      int64  // timestamp of the call as unix time
 }
 
 // newCallTemplateData returns new call template data
 func newCallTemplateData(mtd *desc.MethodDescriptor, reqNum int64) *callTemplateData {
+	now := time.Now()
 	return &callTemplateData{
 		RequestNumber:      reqNum,
 		FullyQualifiedName: mtd.GetFullyQualifiedName(),
@@ -30,6 +35,8 @@ func newCallTemplateData(mtd *desc.MethodDescriptor, reqNum int64) *callTemplate
 		OutputName:         mtd.GetOutputType().GetName(),
 		IsClientStreaming:  mtd.IsClientStreaming(),
 		IsServerStreaming:  mtd.IsServerStreaming(),
+		Timestamp:          now.Format(time.RFC3339),
+		TimestampUnix:      now.Unix(),
 	}
 }
 

--- a/call_template_data.go
+++ b/call_template_data.go
@@ -11,7 +11,7 @@ import (
 
 // call template data
 type callTemplateData struct {
-	RequestNumber      int64  // unique request number for each request
+	RequestNumber      int64  // unique incrememnted request number for each request
 	FullyQualifiedName string // fully-qualified name of the method call
 	MethodName         string // shorter call method name
 	ServiceName        string // the service name
@@ -26,6 +26,7 @@ type callTemplateData struct {
 // newCallTemplateData returns new call template data
 func newCallTemplateData(mtd *desc.MethodDescriptor, reqNum int64) *callTemplateData {
 	now := time.Now()
+
 	return &callTemplateData{
 		RequestNumber:      reqNum,
 		FullyQualifiedName: mtd.GetFullyQualifiedName(),
@@ -42,14 +43,12 @@ func newCallTemplateData(mtd *desc.MethodDescriptor, reqNum int64) *callTemplate
 
 func (td *callTemplateData) execute(data string) (*bytes.Buffer, error) {
 	t := template.Must(template.New("call_template_data").Parse(data))
-
 	var tpl bytes.Buffer
 	err := t.Execute(&tpl, td)
 	return &tpl, err
 }
 
 func (td *callTemplateData) executeData(data string) (interface{}, error) {
-
 	input := []byte(data)
 	tpl, err := td.execute(data)
 	if err == nil {

--- a/call_template_data.go
+++ b/call_template_data.go
@@ -1,0 +1,81 @@
+package ghz
+
+import (
+	"bytes"
+	"encoding/json"
+	"text/template"
+
+	"github.com/jhump/protoreflect/desc"
+)
+
+type callTemplateData struct {
+	RequestNumber      int64
+	FullyQualifiedName string
+	MethodName         string
+	ServiceName        string
+	InputName          string
+	OutputName         string
+	IsClientStreaming  bool
+	IsServerStreaming  bool
+}
+
+// newCallTemplateData returns new call template data
+func newCallTemplateData(mtd *desc.MethodDescriptor, reqNum int64) *callTemplateData {
+	return &callTemplateData{
+		RequestNumber:      reqNum,
+		FullyQualifiedName: mtd.GetFullyQualifiedName(),
+		MethodName:         mtd.GetName(),
+		ServiceName:        mtd.GetService().GetName(),
+		InputName:          mtd.GetInputType().GetName(),
+		OutputName:         mtd.GetOutputType().GetName(),
+		IsClientStreaming:  mtd.IsClientStreaming(),
+		IsServerStreaming:  mtd.IsServerStreaming(),
+	}
+}
+
+func (td *callTemplateData) execute(data string) (*bytes.Buffer, error) {
+	var err error
+
+	t := template.New("call_template_data")
+	t, err = t.Parse(data)
+	if err != nil {
+		return nil, err
+	}
+
+	var tpl bytes.Buffer
+	err = t.Execute(&tpl, td)
+	return &tpl, err
+}
+
+func (td *callTemplateData) executeData(data string) (interface{}, error) {
+
+	var tpl *bytes.Buffer
+	var err error
+	if tpl, err = td.execute(data); err != nil {
+		return nil, err
+	}
+
+	var dataMap interface{}
+	err = json.Unmarshal(tpl.Bytes(), &dataMap)
+	if err != nil {
+		return nil, err
+	}
+
+	return dataMap, nil
+}
+
+func (td *callTemplateData) executeMetadata(metadata string) (*map[string]string, error) {
+	var tpl *bytes.Buffer
+	var err error
+	if tpl, err = td.execute(metadata); err != nil {
+		return nil, err
+	}
+
+	var mdMap map[string]string
+	err = json.Unmarshal(tpl.Bytes(), &mdMap)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mdMap, nil
+}

--- a/call_template_data_test.go
+++ b/call_template_data_test.go
@@ -1,0 +1,120 @@
+package ghz
+
+import (
+	"testing"
+
+	"github.com/bojand/ghz/protodesc"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCallTemplateData_New(t *testing.T) {
+	md, err := protodesc.GetMethodDescFromProto("helloworld.Greeter/SayHello", "./testdata/greeter.proto", []string{})
+	assert.NoError(t, err)
+	assert.NotNil(t, md)
+
+	ctd := newCallTemplateData(md, 100)
+
+	assert.NotNil(t, ctd)
+	assert.Equal(t, int64(100), ctd.RequestNumber)
+	assert.Equal(t, "helloworld.Greeter.SayHello", ctd.FullyQualifiedName)
+	assert.Equal(t, "SayHello", ctd.MethodName)
+	assert.Equal(t, "Greeter", ctd.ServiceName)
+	assert.Equal(t, "HelloRequest", ctd.InputName)
+	assert.Equal(t, "HelloReply", ctd.OutputName)
+	assert.Equal(t, false, ctd.IsClientStreaming)
+	assert.Equal(t, false, ctd.IsServerStreaming)
+	assert.NotEmpty(t, ctd.Timestamp)
+	assert.NotZero(t, ctd.TimestampUnix)
+}
+
+func TestCallTemplateData_ExecuteData(t *testing.T) {
+	md, err := protodesc.GetMethodDescFromProto("helloworld.Greeter/SayHello", "./testdata/greeter.proto", []string{})
+	assert.NoError(t, err)
+	assert.NotNil(t, md)
+
+	ctd := newCallTemplateData(md, 200)
+
+	assert.NotNil(t, ctd)
+
+	var tests = []struct {
+		name        string
+		in          string
+		expected    interface{}
+		expectError bool
+	}{
+		{"no template",
+			`{"name":"bob"}`,
+			map[string]interface{}{"name": "bob"},
+			false,
+		},
+		{"with template",
+			`{"name":"{{.RequestNumber}} bob {{.FullyQualifiedName}} {{.MethodName}} {{.ServiceName}} {{.InputName}} {{.OutputName}} {{.IsClientStreaming}} {{.IsServerStreaming}}"}`,
+			map[string]interface{}{"name": "200 bob helloworld.Greeter.SayHello SayHello Greeter HelloRequest HelloReply false false"},
+			false,
+		},
+		{"with unknown action",
+			`{"name":"asdf {{.Something}} {{.MethodName}} bob"}`,
+			map[string]interface{}{"name": "asdf {{.Something}} {{.MethodName}} bob"},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := ctd.executeData(tt.in)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.expected, r)
+		})
+	}
+}
+
+func TestCallTemplateData_ExecuteMetadata(t *testing.T) {
+	md, err := protodesc.GetMethodDescFromProto("helloworld.Greeter/SayHello", "./testdata/greeter.proto", []string{})
+	assert.NoError(t, err)
+	assert.NotNil(t, md)
+
+	ctd := newCallTemplateData(md, 200)
+
+	assert.NotNil(t, ctd)
+
+	var tests = []struct {
+		name        string
+		in          string
+		expected    interface{}
+		expectError bool
+	}{
+		{"no template",
+			`{"trace_id":"asdf"}`,
+			&map[string]string{"trace_id": "asdf"},
+			false,
+		},
+		{"with template",
+			`{"trace_id":"{{.RequestNumber}} asdf {{.FullyQualifiedName}} {{.MethodName}} {{.ServiceName}} {{.InputName}} {{.OutputName}} {{.IsClientStreaming}} {{.IsServerStreaming}}"}`,
+			&map[string]string{"trace_id": "200 asdf helloworld.Greeter.SayHello SayHello Greeter HelloRequest HelloReply false false"},
+			false,
+		},
+		{"with unknown action",
+			`{"trace_id":"asdf {{.Something}} {{.MethodName}} bob"}`,
+			&map[string]string{"trace_id": "asdf {{.Something}} {{.MethodName}} bob"},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := ctd.executeMetadata(tt.in)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.expected, r)
+		})
+	}
+}

--- a/requester.go
+++ b/requester.go
@@ -73,14 +73,14 @@ func New(mtd *desc.MethodDescriptor, c *Options) (*Requester, error) {
 		return nil, fmt.Errorf("No input type of method: %s", mtd.GetName())
 	}
 
-	// we need data and metadata in string format so
+	// we need data in string format so
 	// we can do template evaluation on it for every call
 	dataJSON, err := json.Marshal(c.Data)
 	if err != nil {
 		return nil, err
 	}
 
-	// we need data and metadata in string format so
+	// we need metadata in string format so
 	// we can do template evaluation on it for every call
 	mdJSON, err := json.Marshal(c.Metadata)
 	if err != nil {

--- a/requester.go
+++ b/requester.go
@@ -3,10 +3,12 @@ package ghz
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/jhump/protoreflect/desc"
@@ -23,7 +25,7 @@ import (
 type Options struct {
 	Host          string
 	Cert          string
-	CName		  string
+	CName         string
 	N             int
 	C             int
 	QPS           int
@@ -47,18 +49,20 @@ type callResult struct {
 
 // Requester is used for doing the requests
 type Requester struct {
-	cc          *grpc.ClientConn
-	stub        grpcdynamic.Stub
-	mtd         *desc.MethodDescriptor
-	input       *dynamic.Message
-	streamInput *[]*dynamic.Message
-	reqMD       *metadata.MD
-	reporter    *Reporter
+	cc       *grpc.ClientConn
+	stub     grpcdynamic.Stub
+	mtd      *desc.MethodDescriptor
+	reporter *Reporter
+
+	data     string
+	metadata string
 
 	config  *Options
 	results chan *callResult
 	stopCh  chan bool
 	start   time.Time
+
+	reqCounter int64
 }
 
 // New creates new Requester
@@ -69,22 +73,27 @@ func New(mtd *desc.MethodDescriptor, c *Options) (*Requester, error) {
 		return nil, fmt.Errorf("No input type of method: %s", mtd.GetName())
 	}
 
-	input, streamInput, err := createPayloads(c.Data, mtd)
+	// we need data and metadata in string format so
+	// we can do template evaluation on it for every call
+	dataJSON, err := json.Marshal(c.Data)
 	if err != nil {
 		return nil, err
 	}
 
-	// metadata
-	var reqMD *metadata.MD
-	if c.Metadata != nil && len(*c.Metadata) > 0 {
-		md := metadata.New(*c.Metadata)
-		reqMD = &md
+	// we need data and metadata in string format so
+	// we can do template evaluation on it for every call
+	mdJSON, err := json.Marshal(c.Metadata)
+	if err != nil {
+		return nil, err
 	}
 
-	return &Requester{config: c,
-		input:       input,
-		streamInput: streamInput,
-		reqMD:       reqMD, mtd: mtd}, nil
+	reqr := &Requester{
+		config:   c,
+		data:     string(dataJSON),
+		metadata: string(mdJSON),
+		mtd:      mtd}
+
+	return reqr, nil
 }
 
 // Run makes all the requests and returns a report of results
@@ -195,12 +204,39 @@ func (b *Requester) runWorker(n int) {
 			if b.config.QPS > 0 {
 				<-throttle
 			}
+
 			b.makeRequest()
 		}
 	}
 }
 
 func (b *Requester) makeRequest() {
+
+	reqNum := atomic.AddInt64(&b.reqCounter, 1)
+
+	ctd := newCallTemplateData(b.mtd, reqNum)
+
+	dataMap, err := ctd.executeData(b.data)
+	if err != nil {
+		return
+	}
+
+	mdMap, err := ctd.executeMetadata(b.metadata)
+	if err != nil {
+		return
+	}
+
+	var reqMD *metadata.MD
+	if mdMap != nil && len(*mdMap) > 0 {
+		md := metadata.New(*mdMap)
+		reqMD = &md
+	}
+
+	input, streamInput, err := createPayloads(dataMap, b.mtd)
+	if err != nil {
+		return
+	}
+
 	ctx := context.Background()
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -210,28 +246,28 @@ func (b *Requester) makeRequest() {
 	ctx, _ = context.WithTimeout(ctx, timeout)
 
 	// include the metadata
-	if b.reqMD != nil {
-		ctx = metadata.NewOutgoingContext(ctx, *b.reqMD)
+	if reqMD != nil {
+		ctx = metadata.NewOutgoingContext(ctx, *reqMD)
 	}
 
 	if b.mtd.IsClientStreaming() && b.mtd.IsServerStreaming() {
-		b.makeBidiRequest(&ctx)
+		b.makeBidiRequest(&ctx, streamInput)
 	} else if b.mtd.IsClientStreaming() {
-		b.makeClientStreamingRequest(&ctx)
+		b.makeClientStreamingRequest(&ctx, streamInput)
 	} else if b.mtd.IsServerStreaming() {
-		b.makeServerStreamingRequest(&ctx)
+		b.makeServerStreamingRequest(&ctx, input)
 	} else {
-		b.stub.InvokeRpc(ctx, b.mtd, b.input)
+		b.stub.InvokeRpc(ctx, b.mtd, input)
 	}
 }
 
-func (b *Requester) makeClientStreamingRequest(ctx *context.Context) {
+func (b *Requester) makeClientStreamingRequest(ctx *context.Context, input *[]*dynamic.Message) {
 	str, err := b.stub.InvokeRpcClientStream(*ctx, b.mtd)
 	counter := 0
 	for err == nil {
-		streamInput := *b.streamInput
+		streamInput := *input
 		inputLen := len(streamInput)
-		if b.streamInput == nil || inputLen == 0 {
+		if input == nil || inputLen == 0 {
 			str.CloseAndReceive()
 			break
 		}
@@ -253,8 +289,8 @@ func (b *Requester) makeClientStreamingRequest(ctx *context.Context) {
 	}
 }
 
-func (b *Requester) makeServerStreamingRequest(ctx *context.Context) {
-	str, err := b.stub.InvokeRpcServerStream(*ctx, b.mtd, b.input)
+func (b *Requester) makeServerStreamingRequest(ctx *context.Context, input *dynamic.Message) {
+	str, err := b.stub.InvokeRpcServerStream(*ctx, b.mtd, input)
 	for err == nil {
 		_, err := str.RecvMsg()
 		if err != nil {
@@ -266,13 +302,13 @@ func (b *Requester) makeServerStreamingRequest(ctx *context.Context) {
 	}
 }
 
-func (b *Requester) makeBidiRequest(ctx *context.Context) {
+func (b *Requester) makeBidiRequest(ctx *context.Context, input *[]*dynamic.Message) {
 	str, err := b.stub.InvokeRpcBidiStream(*ctx, b.mtd)
 	counter := 0
 	for err == nil {
-		streamInput := *b.streamInput
+		streamInput := *input
 		inputLen := len(streamInput)
-		if b.streamInput == nil || inputLen == 0 {
+		if input == nil || inputLen == 0 {
 			str.CloseSend()
 			break
 		}

--- a/testdata/config.json
+++ b/testdata/config.json
@@ -1,0 +1,14 @@
+{
+  "x": "7s",
+  "n": 50000,
+  "c": 50,
+  "proto": "../../testdata/greeter.proto",
+  "call": "helloworld.Greeter.SayHellos",
+  "d": {
+    "name": "Bob {{.TimestampUnix}}"
+  },
+  "m": {
+    "rn": "{{.RequestNumber}}"
+  },
+  "host": "0.0.0.0:50051"
+}


### PR DESCRIPTION
Data and metadata can specify [template actions](https://golang.org/pkg/text/template/) that will be parsed and evaluated at every request. Each request gets a new instance of the data. The available variables / actions are:

```go
// call template data
type callTemplateData struct {
	RequestNumber      int64  // unique incrememnted request number for each request
	FullyQualifiedName string // fully-qualified name of the method call
	MethodName         string // shorter call method name
	ServiceName        string // the service name
	InputName          string // name of the input message type
	OutputName         string // name of the output message type
	IsClientStreaming  bool   // whether this call is client streaming
	IsServerStreaming  bool   // whether this call is server streaming
	Timestamp          string // timestamp of the call in RFC3339 format
	TimestampUnix      int64  // timestamp of the call as unix time
}
```

This can be useful to inject variable information into the data or metadata payload for each request, such as timestamp or unique request number. Example:

```sh
$ ghz -proto ./greeter.proto -call helloworld.Greeter.SayHello -d '{"name":"Joe"}' -m '{"trace_id":"{{.RequestNumber}}","timestamp":"{{.TimestampUnix}}"}' 0.0.0.0:50051
```

This ends up substituting the template variables with the request number and unix timestamp respectively.