### PR TITLE
Remove unused parseConfigString from config.go

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -349,10 +349,6 @@ func minValue(v int, min int) error {
 	return nil
 }
 
-func parseConfigString(s string) (*Config, error) {
-	return parseConfig([]byte(s))
-}
-
 func parseConfig(b []byte) (*Config, error) {
 	c := &Config{}
 


### PR DESCRIPTION
I found an unused method at config.go.

@bojand please review 🙏 