### PR TITLE
Fix TLS credential options

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Options:
 -cert		File containing client certificate (public key), to present to the server. Must also provide -key option.
 -key 		File containing client private key, to present to the server. Must also provide -cert option.
 -cname		Server name override when validating TLS certificate - useful for self signed certs.
--no-verify	Skip TLS client verification of the server's certificate chain and host name.
+-skipTLS	Skip TLS client verification of the server's certificate chain and host name.
 -insecure	Use plaintext and insecure connection.
 -authority	Value to be used as the :authority pseudo-header. Only works if -insecure is used.
 
@@ -54,11 +54,11 @@ Options:
 
 -d  The call data as stringified JSON.
     If the value is '@' then the request contents are read from stdin.
--D  File path for call data JSON file. Examples: /home/user/file.json or ./file.json.
+-D  Path for call data JSON file. Examples: /home/user/file.json or ./file.json.
 -b  The call data comes as serialized binary message read from stdin.
--B  File path for the call data as serialized binary message.
+-B  Path for the call data as serialized binary message.
 -m  Request metadata as stringified JSON.
--M  File path for call metadata JSON file. Examples: /home/user/metadata.json or ./metadata.json.
+-M  Path for call metadata JSON file. Examples: /home/user/metadata.json or ./metadata.json.
 
 -o  Output path. If none provided stdout is used.
 -O  Output type. If none provided, a summary is printed.
@@ -75,7 +75,7 @@ Options:
 -name  User specified name for the test.
 -tags  JSON representation of user-defined string tags.
 
--cpus  Number of used cpu cores. (default for current machine is 8 cores)
+-cpus  Number of used cpu cores.
 
 -v  Print the version.
 ```

--- a/README.md
+++ b/README.md
@@ -25,33 +25,40 @@ All documentation at [ghz.sh](https://ghz.sh).
 Usage: ghz [options...] host
 Options:
 
+-config	Path to the JSON or TOML config file that specifies all the test run settings.
+
 -proto		The Protocol Buffer .proto file.
 -protoset	The compiled protoset file. Alternative to proto. -proto takes precedence.
 -call		A fully-qualified method name in 'package/service/method' or 'package.service.method' format.
--cert		The file containing the CA root cert file. Ignored if -insecure is specified.
--cname		An server name override.
--insecure	Specify for non TLS connection.
--config		Path to the JSON or TOML config file that specifies all the test settings.
+-i		Comma separated list of proto import paths. The current working directory and the directory
+		of the protocol buffer file are automatically added to the import list.
+
+-cacert		File containing trusted root certificates for verifying the server.
+-cert		File containing client certificate (public key), to present to the server. Must also provide -key option.
+-key 		File containing client private key, to present to the server. Must also provide -cert option.
+-cname		Server name override when validating TLS certificate - useful for self signed certs.
+-no-verify	Skip TLS client verification of the server's certificate chain and host name.
+-insecure	Use plaintext and insecure connection.
+-authority	Value to be used as the :authority pseudo-header. Only works if -insecure is used.
 
 -c  Number of requests to run concurrently.
     Total number of requests cannot be smaller than the concurrency level. Default is 50.
 -n  Number of requests to run. Default is 200.
 -q  Rate limit, in queries per second (QPS). Default is no rate limit.
 -t  Timeout for each request in seconds. Default is 20, use 0 for infinite.
--z  Duration of application to send requests. When duration is reached,
-	application stops and exits. If duration is specified, n is ignored.
-	Examples: -z 10s -z 3m.
+-z  Duration of application to send requests. When duration is reached, application stops and exits.
+    If duration is specified, n is ignored. Examples: -z 10s -z 3m.
 -x  Maximum duration of application to send requests with n setting respected.
     If duration is reached before n requests are completed, application stops and exits.
     Examples: -x 10s -x 3m.
 
 -d  The call data as stringified JSON.
     If the value is '@' then the request contents are read from stdin.
--D  Path for call data JSON file. For example, /home/user/file.json or ./file.json.
+-D  File path for call data JSON file. Examples: /home/user/file.json or ./file.json.
 -b  The call data comes as serialized binary message read from stdin.
--B  Path for the call data as serialized binary message.
+-B  File path for the call data as serialized binary message.
 -m  Request metadata as stringified JSON.
--M  Path for call metadata JSON file. For example, /home/user/metadata.json or ./metadata.json.
+-M  File path for call metadata JSON file. Examples: /home/user/metadata.json or ./metadata.json.
 
 -o  Output path. If none provided stdout is used.
 -O  Output type. If none provided, a summary is printed.
@@ -61,9 +68,6 @@ Options:
     "html" outputs the metrics report as HTML.
     "influx-summary" outputs the metrics summary as influxdb line protocol.
     "influx-details" outputs the metrics details as influxdb line protocol.
-
--i  Comma separated list of proto import paths. The current working directory and the directory
-    of the protocol buffer file are automatically added to the import list.
 
 -T  Connection timeout in seconds for the initial connection dial. Default is 10.
 -L  Keepalive time in seconds. Only used if present and above 0.

--- a/cmd/ghz/config.go
+++ b/cmd/ghz/config.go
@@ -21,7 +21,10 @@ type config struct {
 	Proto         string             `json:"proto" toml:"proto" yaml:"proto"`
 	Protoset      string             `json:"protoset" toml:"protoset" yaml:"protoset"`
 	Call          string             `json:"call" toml:"call" yaml:"call" required:"true"`
+	RootCert      string             `json:"cacert" toml:"cacert" yaml:"cacert"`
 	Cert          string             `json:"cert" toml:"cert" yaml:"cert"`
+	Key           string             `json:"key" toml:"key" yaml:"key"`
+	SkipTLSVerify bool               `json:"skipTLSVerify" toml:"skipTLSVerify" yaml:"skipTLSVerify"`
 	CName         string             `json:"cname" toml:"cname" yaml:"cname"`
 	N             uint               `json:"n" toml:"n" yaml:"n" default:"200"`
 	C             uint               `json:"c" toml:"c" yaml:"c" default:"50"`

--- a/cmd/ghz/config.go
+++ b/cmd/ghz/config.go
@@ -24,7 +24,7 @@ type config struct {
 	RootCert      string             `json:"cacert" toml:"cacert" yaml:"cacert"`
 	Cert          string             `json:"cert" toml:"cert" yaml:"cert"`
 	Key           string             `json:"key" toml:"key" yaml:"key"`
-	SkipTLSVerify bool               `json:"skipTLSVerify" toml:"skipTLSVerify" yaml:"skipTLSVerify"`
+	SkipTLSVerify bool               `json:"skipTLS" toml:"skipTLS" yaml:"skipTLS"`
 	CName         string             `json:"cname" toml:"cname" yaml:"cname"`
 	N             uint               `json:"n" toml:"n" yaml:"n" default:"200"`
 	C             uint               `json:"c" toml:"c" yaml:"c" default:"50"`

--- a/cmd/ghz/main.go
+++ b/cmd/ghz/main.go
@@ -31,7 +31,7 @@ var (
 	cert       = flag.String("cert", "", "File containing client certificate (public key), to present to the server. Must also provide -key option.")
 	key        = flag.String("key", "", "File containing client private key, to present to the server. Must also provide -cert option.")
 	cname      = flag.String("cname", "", "Server name override when validating TLS certificate - useful for self signed certs.")
-	skipVerify = flag.Bool("no-verify", false, "Skip TLS client verification of the server's certificate chain and host name.")
+	skipVerify = flag.Bool("skipTLS", false, "Skip TLS client verification of the server's certificate chain and host name.")
 	insecure   = flag.Bool("insecure", false, "Use plaintext and insecure connection.")
 	authority  = flag.String("authority", "", "Value to be used as the :authority pseudo-header. Only works if -insecure is used.")
 
@@ -78,7 +78,7 @@ Options:
 -cert		File containing client certificate (public key), to present to the server. Must also provide -key option.
 -key 		File containing client private key, to present to the server. Must also provide -cert option.
 -cname		Server name override when validating TLS certificate - useful for self signed certs.
--no-verify	Skip TLS client verification of the server's certificate chain and host name.
+-skipTLS	Skip TLS client verification of the server's certificate chain and host name.
 -insecure	Use plaintext and insecure connection.
 -authority	Value to be used as the :authority pseudo-header. Only works if -insecure is used.
 
@@ -95,11 +95,11 @@ Options:
 
 -d  The call data as stringified JSON.
     If the value is '@' then the request contents are read from stdin.
--D  File path for call data JSON file. Examples: /home/user/file.json or ./file.json.
+-D  Path for call data JSON file. Examples: /home/user/file.json or ./file.json.
 -b  The call data comes as serialized binary message read from stdin.
--B  File path for the call data as serialized binary message.
+-B  Path for the call data as serialized binary message.
 -m  Request metadata as stringified JSON.
--M  File path for call metadata JSON file. Examples: /home/user/metadata.json or ./metadata.json.
+-M  Path for call metadata JSON file. Examples: /home/user/metadata.json or ./metadata.json.
 
 -o  Output path. If none provided stdout is used.
 -O  Output type. If none provided, a summary is printed.

--- a/cmd/ghz/main.go
+++ b/cmd/ghz/main.go
@@ -23,10 +23,15 @@ var (
 	proto    = flag.String("proto", "", `The Protocol Buffer .proto file.`)
 	protoset = flag.String("protoset", "", `The .protoset file.`)
 	call     = flag.String("call", "", `A fully-qualified symbol name.`)
-	cert     = flag.String("cert", "", "Client certificate file. If Omitted insecure is used.")
-	cname    = flag.String("cname", "", "Server name override - useful for self signed certs.")
-	insecure = flag.Bool("insecure", false, "Specify for non TLS connection")
-	cPath    = flag.String("config", "", "Path to the config JSON file.")
+
+	cacert     = flag.String("cacert", "", "File containing trusted root certificates for verifying the server.")
+	cert       = flag.String("cert", "", "File containing client certificate (public key), to present to the server. Must also provide -key option.")
+	key        = flag.String("key", "", "File containing client private key, to present to the server. Must also provide -cert option.")
+	cname      = flag.String("cname", "", "Server name override when validating TLS certificate - useful for self signed certs.")
+	skipVerify = flag.Bool("skip-tls-verify", false, "Skip TLS client verification of the server's certificate chain and host name.")
+	insecure   = flag.Bool("insecure", false, "Specify for plantext and insecure (non TLS) connection")
+
+	cPath = flag.String("config", "", "Path to the config JSON file.")
 
 	c = flag.Uint("c", 50, "Number of requests to run concurrently.")
 	n = flag.Uint("n", 200, "Number of requests to run. Default is 200.")
@@ -114,7 +119,8 @@ Options:
 
 func main() {
 	flag.Usage = func() {
-		fmt.Fprint(os.Stderr, fmt.Sprintf(usage, runtime.NumCPU()))
+		flag.PrintDefaults()
+		// fmt.Fprint(os.Stderr, fmt.Sprintf(usage, runtime.NumCPU()))
 	}
 
 	flag.Parse()
@@ -161,7 +167,10 @@ func main() {
 	options = append(options,
 		runner.WithProtoFile(cfg.Proto, cfg.ImportPaths),
 		runner.WithProtoset(cfg.Protoset),
-		runner.WithCertificate(cfg.Cert, cfg.CName),
+		runner.WithRootCertificate(cfg.RootCert),
+		runner.WithCertificate(cfg.Cert, cfg.Key),
+		runner.WithServerNameOverride(cfg.CName),
+		runner.WithSkipTLSVerify(cfg.SkipTLSVerify),
 		runner.WithInsecure(cfg.Insecure),
 		runner.WithConcurrency(cfg.C),
 		runner.WithTotalRequests(cfg.N),

--- a/cmd/ghz/main.go
+++ b/cmd/ghz/main.go
@@ -20,45 +20,45 @@ var (
 	// set by goreleaser with -ldflags="-X main.version=..."
 	version = "dev"
 
+	cPath = flag.String("config", "", "Path to the JSON or TOML config file that specifies all the test run settings.")
+
 	proto    = flag.String("proto", "", `The Protocol Buffer .proto file.`)
-	protoset = flag.String("protoset", "", `The .protoset file.`)
-	call     = flag.String("call", "", `A fully-qualified symbol name.`)
+	protoset = flag.String("protoset", "", `The compiled protoset file. Alternative to proto. -proto takes precedence.`)
+	call     = flag.String("call", "", `A fully-qualified method name in 'package/service/method' or 'package.service.method' format.`)
+	paths    = flag.String("i", "", "Comma separated list of proto import paths. The current working directory and the directory of the protocol buffer file are automatically added to the import list.")
 
 	cacert     = flag.String("cacert", "", "File containing trusted root certificates for verifying the server.")
 	cert       = flag.String("cert", "", "File containing client certificate (public key), to present to the server. Must also provide -key option.")
 	key        = flag.String("key", "", "File containing client private key, to present to the server. Must also provide -cert option.")
 	cname      = flag.String("cname", "", "Server name override when validating TLS certificate - useful for self signed certs.")
-	skipVerify = flag.Bool("skip-tls-verify", false, "Skip TLS client verification of the server's certificate chain and host name.")
-	insecure   = flag.Bool("insecure", false, "Specify for plantext and insecure (non TLS) connection")
+	skipVerify = flag.Bool("no-verify", false, "Skip TLS client verification of the server's certificate chain and host name.")
+	insecure   = flag.Bool("insecure", false, "Use plaintext and insecure connection.")
+	authority  = flag.String("authority", "", "Value to be used as the :authority pseudo-header. Only works if -insecure is used.")
 
-	cPath = flag.String("config", "", "Path to the config JSON file.")
-
-	c = flag.Uint("c", 50, "Number of requests to run concurrently.")
+	c = flag.Uint("c", 50, "Number of requests to run concurrently. Total number of requests cannot be smaller than the concurrency level. Default is 50.")
 	n = flag.Uint("n", 200, "Number of requests to run. Default is 200.")
 	q = flag.Uint("q", 0, "Rate limit, in queries per second (QPS). Default is no rate limit.")
-	t = flag.Uint("t", 20, "Timeout for each request in seconds.")
-	z = flag.Duration("z", 0, "Duration of application to send requests.")
-	x = flag.Duration("x", 0, "Maximum duration of application to send requests.")
+	t = flag.Uint("t", 20, "Timeout for each request in seconds. Default is 20, use 0 for infinite.")
+	z = flag.Duration("z", 0, "Duration of application to send requests. When duration is reached, application stops and exits. If duration is specified, n is ignored. Examples: -z 10s -z 3m.")
+	x = flag.Duration("x", 0, "Maximum duration of application to send requests with n setting respected. If duration is reached before n requests are completed, application stops and exits. Examples: -x 10s -x 3m.")
 
 	data     = flag.String("d", "", "The call data as stringified JSON. If the value is '@' then the request contents are read from stdin.")
-	dataPath = flag.String("D", "", "Path for call data JSON file.")
-	binData  = flag.Bool("b", false, "The call data as serialized binary message read from stdin.")
-	binPath  = flag.String("B", "", "The call data as serialized binary message read from a file.")
+	dataPath = flag.String("D", "", "File path for call data JSON file. Examples: /home/user/file.json or ./file.json.")
+	binData  = flag.Bool("b", false, "The call data comes as serialized binary message read from stdin.")
+	binPath  = flag.String("B", "", "File path for the call data as serialized binary message.")
 	md       = flag.String("m", "", "Request metadata as stringified JSON.")
-	mdPath   = flag.String("M", "", "Path for call metadata JSON file.")
+	mdPath   = flag.String("M", "", "File path for call metadata JSON file. Examples: /home/user/metadata.json or ./metadata.json.")
 
-	paths = flag.String("i", "", "Comma separated list of proto import paths")
+	output = flag.String("o", "", "Output path. If none provided stdout is used.")
+	format = flag.String("O", "", "Output format. If none provided, a summary is printed.")
 
-	output = flag.String("o", "", "Output path")
-	format = flag.String("O", "", "Output format")
-
-	ct = flag.Uint("T", 10, "Connection timeout in seconds for the initial connection dial.")
-	kt = flag.Uint("L", 0, "Keepalive time in seconds.")
+	ct = flag.Uint("T", 10, "Connection timeout in seconds for the initial connection dial. Default is 10.")
+	kt = flag.Uint("L", 0, "Keepalive time in seconds. Only used if present and above 0.")
 
 	name = flag.String("name", "", "User specified name for the test.")
 	tags = flag.String("tags", "", "JSON representation of user-defined string tags.")
 
-	cpus = flag.Uint("cpus", uint(runtime.GOMAXPROCS(-1)), "")
+	cpus = flag.Uint("cpus", uint(runtime.GOMAXPROCS(-1)), "Number of used cpu cores.")
 
 	v = flag.Bool("v", false, "Print the version.")
 )
@@ -66,33 +66,40 @@ var (
 var usage = `Usage: ghz [options...] host
 Options:
 
+-config	Path to the JSON or TOML config file that specifies all the test run settings.
+
 -proto		The Protocol Buffer .proto file.
 -protoset	The compiled protoset file. Alternative to proto. -proto takes precedence.
 -call		A fully-qualified method name in 'package/service/method' or 'package.service.method' format.
--cert		The file containing the CA root cert file. Ignored if -insecure is specified.
--cname		An server name override.
--insecure	Specify for non TLS connection.
--config		Path to the JSON or TOML config file that specifies all the test settings.
+-i		Comma separated list of proto import paths. The current working directory and the directory
+		of the protocol buffer file are automatically added to the import list.
+	
+-cacert		File containing trusted root certificates for verifying the server.
+-cert		File containing client certificate (public key), to present to the server. Must also provide -key option.
+-key 		File containing client private key, to present to the server. Must also provide -cert option.
+-cname		Server name override when validating TLS certificate - useful for self signed certs.
+-no-verify	Skip TLS client verification of the server's certificate chain and host name.
+-insecure	Use plaintext and insecure connection.
+-authority	Value to be used as the :authority pseudo-header. Only works if -insecure is used.
 
 -c  Number of requests to run concurrently. 
     Total number of requests cannot be smaller than the concurrency level. Default is 50.
 -n  Number of requests to run. Default is 200.
 -q  Rate limit, in queries per second (QPS). Default is no rate limit.
 -t  Timeout for each request in seconds. Default is 20, use 0 for infinite.
--z  Duration of application to send requests. When duration is reached,
-	application stops and exits. If duration is specified, n is ignored.
-	Examples: -z 10s -z 3m.
+-z  Duration of application to send requests. When duration is reached, application stops and exits.
+    If duration is specified, n is ignored. Examples: -z 10s -z 3m.
 -x  Maximum duration of application to send requests with n setting respected.
     If duration is reached before n requests are completed, application stops and exits.
     Examples: -x 10s -x 3m.
 
 -d  The call data as stringified JSON.
     If the value is '@' then the request contents are read from stdin.
--D  Path for call data JSON file. For example, /home/user/file.json or ./file.json.
+-D  File path for call data JSON file. Examples: /home/user/file.json or ./file.json.
 -b  The call data comes as serialized binary message read from stdin.
--B  Path for the call data as serialized binary message.
+-B  File path for the call data as serialized binary message.
 -m  Request metadata as stringified JSON.
--M  Path for call metadata JSON file. For example, /home/user/metadata.json or ./metadata.json.
+-M  File path for call metadata JSON file. Examples: /home/user/metadata.json or ./metadata.json.
 
 -o  Output path. If none provided stdout is used.
 -O  Output type. If none provided, a summary is printed.
@@ -102,9 +109,6 @@ Options:
     "html" outputs the metrics report as HTML.
     "influx-summary" outputs the metrics summary as influxdb line protocol.
     "influx-details" outputs the metrics details as influxdb line protocol.
-
--i  Comma separated list of proto import paths. The current working directory and the directory
-    of the protocol buffer file are automatically added to the import list.
 
 -T  Connection timeout in seconds for the initial connection dial. Default is 10.
 -L  Keepalive time in seconds. Only used if present and above 0.
@@ -119,8 +123,7 @@ Options:
 
 func main() {
 	flag.Usage = func() {
-		flag.PrintDefaults()
-		// fmt.Fprint(os.Stderr, fmt.Sprintf(usage, runtime.NumCPU()))
+		fmt.Fprint(os.Stderr, fmt.Sprintf(usage, runtime.NumCPU()))
 	}
 
 	flag.Parse()

--- a/runner/options.go
+++ b/runner/options.go
@@ -33,6 +33,7 @@ type RunConfig struct {
 	cname      string
 	skipVerify bool
 	insecure   bool
+	authority  string
 
 	// test
 	n   int
@@ -77,6 +78,16 @@ func WithCertificate(cert, key string) Option {
 func WithServerNameOverride(cname string) Option {
 	return func(o *RunConfig) error {
 		o.cname = cname
+
+		return nil
+	}
+}
+
+// WithAuthority specifies the value to be used as the :authority pseudo-header.
+// This only works with WithInsecure option.
+func WithAuthority(authority string) Option {
+	return func(o *RunConfig) error {
+		o.authority = authority
 
 		return nil
 	}

--- a/runner/options.go
+++ b/runner/options.go
@@ -1,6 +1,8 @@
 package runner
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -11,6 +13,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"google.golang.org/grpc/credentials"
 )
 
 // RunConfig represents the request Configs
@@ -22,10 +25,14 @@ type RunConfig struct {
 	importPaths []string
 	protoset    string
 
-	// securit settings
-	cert     string
-	cname    string
-	insecure bool
+	// security settings
+	creds      credentials.TransportCredentials
+	cacert     string
+	cert       string
+	key        string
+	cname      string
+	skipVerify bool
+	insecure   bool
 
 	// test
 	n   int
@@ -53,13 +60,35 @@ type RunConfig struct {
 type Option func(*RunConfig) error
 
 // WithCertificate specifies the certificate options for the run
-//	WithCertificate("certfile.crt", "")
-func WithCertificate(cert string, cname string) Option {
+//	WithCertificate("client.crt", "client.key")
+func WithCertificate(cert, key string) Option {
+	return func(o *RunConfig) error {
+		cert = strings.TrimSpace(cert)
+		key = strings.TrimSpace(key)
+
+		o.cert = cert
+		o.key = key
+
+		return nil
+	}
+}
+
+// WithServerNameOverride specifies the certificate options for the run
+func WithServerNameOverride(cname string) Option {
+	return func(o *RunConfig) error {
+		o.cname = cname
+
+		return nil
+	}
+}
+
+// WithRootCertificate specifies the root certificate options for the run
+//	WithRootCertificate("ca.crt")
+func WithRootCertificate(cert string) Option {
 	return func(o *RunConfig) error {
 		cert = strings.TrimSpace(cert)
 
-		o.cert = cert
-		o.cname = cname
+		o.cacert = cert
 
 		return nil
 	}
@@ -70,6 +99,15 @@ func WithCertificate(cert string, cname string) Option {
 func WithInsecure(insec bool) Option {
 	return func(o *RunConfig) error {
 		o.insecure = insec
+
+		return nil
+	}
+}
+
+// WithSkipTLSVerify skip client side TLS verification of server certificate
+func WithSkipTLSVerify(skip bool) Option {
+	return func(o *RunConfig) error {
+		o.skipVerify = skip
 
 		return nil
 	}
@@ -395,5 +433,56 @@ func newConfig(call, host string, options ...Option) (*RunConfig, error) {
 		return nil, errors.New("Must provide proto or protoset")
 	}
 
+	creds, err := createClientTransportCredentials(
+		c.skipVerify,
+		c.cacert,
+		c.cert,
+		c.key,
+		c.cname,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	c.creds = creds
+
 	return c, nil
+}
+
+func createClientTransportCredentials(skipVerify bool, cacertFile, clientCertFile, clientKeyFile, cname string) (credentials.TransportCredentials, error) {
+	var tlsConf tls.Config
+
+	if clientCertFile != "" {
+		// Load the client certificates from disk
+		certificate, err := tls.LoadX509KeyPair(clientCertFile, clientKeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("could not load client key pair: %v", err)
+		}
+		tlsConf.Certificates = []tls.Certificate{certificate}
+	}
+
+	if skipVerify == true {
+		tlsConf.InsecureSkipVerify = true
+	} else if cacertFile != "" {
+		// Create a certificate pool from the certificate authority
+		certPool := x509.NewCertPool()
+		ca, err := ioutil.ReadFile(cacertFile)
+		if err != nil {
+			return nil, fmt.Errorf("could not read ca certificate: %v", err)
+		}
+
+		// Append the certificates from the CA
+		if ok := certPool.AppendCertsFromPEM(ca); !ok {
+			return nil, errors.New("failed to append ca certs")
+		}
+
+		tlsConf.RootCAs = certPool
+	}
+
+	if cname != "" {
+		tlsConf.ServerName = cname
+	}
+
+	return credentials.NewTLS(&tlsConf), nil
 }

--- a/runner/options_test.go
+++ b/runner/options_test.go
@@ -125,7 +125,6 @@ func TestRunConfig_newRunConfig(t *testing.T) {
 	t.Run("with options", func(t *testing.T) {
 		c, err := newConfig(
 			"call", "localhost:50050",
-			WithCertificate("certfile", "somecname"),
 			WithInsecure(true),
 			WithTotalRequests(100),
 			WithConcurrency(20),
@@ -146,8 +145,6 @@ func TestRunConfig_newRunConfig(t *testing.T) {
 		assert.Equal(t, "call", c.call)
 		assert.Equal(t, "localhost:50050", c.host)
 		assert.Equal(t, true, c.insecure)
-		assert.Equal(t, "certfile", c.cert)
-		assert.Equal(t, "somecname", c.cname)
 		assert.Equal(t, 100, c.n)
 		assert.Equal(t, 20, c.c)
 		assert.Equal(t, 5, c.qps)
@@ -169,8 +166,9 @@ func TestRunConfig_newRunConfig(t *testing.T) {
 	t.Run("with binary data, protoset and metadata file", func(t *testing.T) {
 		c, err := newConfig(
 			"call", "localhost:50050",
-			WithCertificate("certfile", "somecname"),
-			WithInsecure(true),
+			WithCertificate("../testdata/localhost.crt", "../testdata/localhost.key"),
+			WithServerNameOverride("cname"),
+			WithAuthority("someauth"),
 			WithTotalRequests(100),
 			WithConcurrency(20),
 			WithQPS(5),
@@ -189,9 +187,11 @@ func TestRunConfig_newRunConfig(t *testing.T) {
 
 		assert.Equal(t, "call", c.call)
 		assert.Equal(t, "localhost:50050", c.host)
-		assert.Equal(t, true, c.insecure)
-		assert.Equal(t, "certfile", c.cert)
-		assert.Equal(t, "somecname", c.cname)
+		assert.Equal(t, false, c.insecure)
+		assert.Equal(t, "../testdata/localhost.crt", c.cert)
+		assert.Equal(t, "../testdata/localhost.key", c.key)
+		assert.Equal(t, "cname", c.cname)
+		assert.Equal(t, "someauth", c.authority)
 		assert.Equal(t, 100, c.n)
 		assert.Equal(t, 20, c.c)
 		assert.Equal(t, 5, c.qps)
@@ -206,6 +206,7 @@ func TestRunConfig_newRunConfig(t *testing.T) {
 		assert.Equal(t, `{"request-id": "{{.RequestNumber}}"}`, string(c.metadata))
 		assert.Equal(t, "", string(c.proto))
 		assert.Equal(t, "testdata/bundle.protoset", string(c.protoset))
+		assert.NotNil(t, c.creds)
 	})
 
 	t.Run("with data interface and metadata map", func(t *testing.T) {
@@ -231,7 +232,7 @@ func TestRunConfig_newRunConfig(t *testing.T) {
 		c, err := newConfig(
 			"call", "localhost:50050",
 			WithProtoFile("testdata/data.proto", []string{}),
-			WithCertificate("certfile", "somecname"),
+			WithCertificate("../testdata/localhost.crt", "../testdata/localhost.key"),
 			WithInsecure(true),
 			WithTotalRequests(100),
 			WithConcurrency(20),
@@ -252,8 +253,8 @@ func TestRunConfig_newRunConfig(t *testing.T) {
 		assert.Equal(t, "call", c.call)
 		assert.Equal(t, "localhost:50050", c.host)
 		assert.Equal(t, true, c.insecure)
-		assert.Equal(t, "certfile", c.cert)
-		assert.Equal(t, "somecname", c.cname)
+		assert.Equal(t, "../testdata/localhost.crt", c.cert)
+		assert.Equal(t, "../testdata/localhost.key", c.key)
 		assert.Equal(t, 100, c.n)
 		assert.Equal(t, 20, c.c)
 		assert.Equal(t, 5, c.qps)
@@ -270,6 +271,7 @@ func TestRunConfig_newRunConfig(t *testing.T) {
 		assert.Equal(t, "testdata/data.proto", string(c.proto))
 		assert.Equal(t, "", string(c.protoset))
 		assert.Equal(t, []string{"testdata", "."}, c.importPaths)
+		assert.NotNil(t, c.creds)
 	})
 
 	t.Run("with binary data from file", func(t *testing.T) {

--- a/runner/requester.go
+++ b/runner/requester.go
@@ -127,6 +127,10 @@ func (b *Requester) connect() (*grpc.ClientConn, error) {
 		opts = append(opts, grpc.WithTransportCredentials(b.config.creds))
 	}
 
+	if b.config.authority != "" {
+		opts = append(opts, grpc.WithAuthority(b.config.authority))
+	}
+
 	ctx := context.Background()
 	ctx, _ = context.WithTimeout(ctx, b.config.dialTimeout)
 	// cancel is ignored here as connection.Close() is used.

--- a/runner/requester.go
+++ b/runner/requester.go
@@ -13,7 +13,6 @@ import (
 	"github.com/jhump/protoreflect/dynamic/grpcdynamic"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 )
@@ -121,12 +120,12 @@ func (b *Requester) Finish() *Report {
 
 func (b *Requester) connect() (*grpc.ClientConn, error) {
 	var opts []grpc.DialOption
-	credOptions, err := createClientCredOption(b.config)
-	if err != nil {
-		return nil, err
-	}
 
-	opts = append(opts, credOptions)
+	if b.config.insecure {
+		opts = append(opts, grpc.WithInsecure())
+	} else {
+		opts = append(opts, grpc.WithTransportCredentials(b.config.creds))
+	}
 
 	ctx := context.Background()
 	ctx, _ = context.WithTimeout(ctx, b.config.dialTimeout)
@@ -320,25 +319,6 @@ func (b *Requester) makeBidiRequest(ctx *context.Context, input *[]*dynamic.Mess
 			break
 		}
 	}
-}
-
-func createClientCredOption(config *RunConfig) (grpc.DialOption, error) {
-	if config.insecure {
-		credOptions := grpc.WithInsecure()
-		return credOptions, nil
-	}
-
-	if config.cert != "" {
-		creds, err := credentials.NewClientTLSFromFile(config.cert, config.cname)
-		if err != nil {
-			return nil, err
-		}
-		credOptions := grpc.WithTransportCredentials(creds)
-		return credOptions, nil
-	}
-
-	credOptions := grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(nil, ""))
-	return credOptions, nil
 }
 
 func min(a, b int) int {

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -472,7 +472,7 @@ func TestRunUnarySecure(t *testing.T) {
 		WithTimeout(time.Duration(20*time.Second)),
 		WithDialTimeout(time.Duration(20*time.Second)),
 		WithData(data),
-		WithCertificate("../testdata/localhost.crt", ""),
+		WithRootCertificate("../testdata/localhost.crt"),
 	)
 
 	assert.NoError(t, err)

--- a/web/todo.md
+++ b/web/todo.md
@@ -1,10 +1,10 @@
-- [ ] Website documentation
-- [ ] Figure out release mechanism
+- [ ] Improve website documentation
+- [ ] Fix ingest status
 - [ ] Make ingest transactional
-- [ ] Invalid request and bad condition tests
 - [ ] Menu in project listing with Delete option ?
 - [ ] Latest run time ago + link in project list (needs DB + API) ?
 - [ ] Add config for host to bind to ?
+- [ ] Improve invalid request and bad condition tests
 - [x] DELETE
 - [x] Lock down demo create
 - [x] Docs

--- a/www/docs/example_config.md
+++ b/www/docs/example_config.md
@@ -4,6 +4,7 @@ title: Configuration Files
 ---
 
 All the call options can be specified in JSON or TOML config files and used as input via the `-config` option. 
+
 An example JSON config file:
 
 ```json

--- a/www/docs/options.md
+++ b/www/docs/options.md
@@ -9,7 +9,7 @@ The `ghz` command line has numerous command line options.  You can run `ghz --he
 
 ### `-proto`
 
-The protocol buffer file for input.
+The path to The Protocol Buffer .proto file for input.
 
 ### `-protoset`
 
@@ -24,29 +24,45 @@ protoc --proto_path=. --descriptor_set_out=bundle.protoset *.proto
 
 A fully-qualified method name in 'package/service/method' or 'package.service.method' format. For example: `helloworld.Greeter.SayHello`.
 
+### `-cacert`
+
+Path to the file containing trusted root certificates for verifying the server. By default `ghz` tries to create a secure connection using the system's default root certificate. The certificate file can be specified using `-cacert` option. The TLS verification can be skipped using `-skipTLS` option.
+
 ### `-cert`
 
-By default `ghz` tries to create a secure connection using the system's default root certificate. The certificate file can be specified using `-cert` option. Ignored if `-insecure` is specified.
+Path to the file containing client certificate (public key), to present to the server. Must also provide `-key` option when this is used.
+
+### `-key`
+
+File containing client private key, to present to the server. Must also provide `-cert` option.
 
 ### `-cname`
 
-An override of the expected server Cname presented by the server.
+Server name override when validating TLS certificate.
+
+### `-skipTLS`
+
+Skip TLS client verification of the server's certificate chain and host name.
 
 ### `-insecure`
 
- Specify for non TLS connection.
+Use plaintext and insecure connection.
 
- ### `-config`
+### `-authority`
 
- Path to the JSON or TOML [config file](example_config.md) that specifies all the test settings.
+Value to be used as the `:authority` pseudo-header. Only works if `-insecure` is used.
 
- ### `-c`
+### `-config`
 
- Number of requests to run concurrently. Total number of requests cannot be smaller than the concurrency level. Default is `50`. For example to do requests in series without any concurrency set to `1`. 
+Path to the JSON or TOML [config file](example_config.md) that specifies all the test settings.
 
- ### `-n`
+### `-c`
 
- The total number of requests to run. Default is `200`. The combination of `-c` and `-n` are critical in how the benchmarking is done. `ghz` takes the `-c` argument and spawns that make worker goroutines. In parallel these goroutines each do their share (`c / n`) requests. So for example with the default `-c 50 -n 200` options we would spawn `50` goroutines which in parallel each do `40` requests. 
+Number of requests to run concurrently. Total number of requests cannot be smaller than the concurrency level. Default is `50`. For example to do requests in series without any concurrency set to `1`. 
+
+### `-n`
+
+The total number of requests to run. Default is `200`. The combination of `-c` and `-n` are critical in how the benchmarking is done. `ghz` takes the `-c` argument and spawns that make worker goroutines. In parallel these goroutines each do their share (`c / n`) requests. So for example with the default `-c 50 -n 200` options we would spawn `50` goroutines which in parallel each do `40` requests. 
 
 ### `-q`
 

--- a/www/docs/usage.md
+++ b/www/docs/usage.md
@@ -7,33 +7,40 @@ title: Usage
 Usage: ghz [options...] host
 Options:
 
+-config	Path to the JSON or TOML config file that specifies all the test run settings.
+
 -proto		The Protocol Buffer .proto file.
 -protoset	The compiled protoset file. Alternative to proto. -proto takes precedence.
 -call		A fully-qualified method name in 'package/service/method' or 'package.service.method' format.
--cert		The file containing the CA root cert file. Ignored if -insecure is specified.
--cname		An server name override.
--insecure	Specify for non TLS connection.
--config		Path to the JSON or TOML config file that specifies all the test settings.
+-i		Comma separated list of proto import paths. The current working directory and the directory
+		of the protocol buffer file are automatically added to the import list.
+
+-cacert		File containing trusted root certificates for verifying the server.
+-cert		File containing client certificate (public key), to present to the server. Must also provide -key option.
+-key 		File containing client private key, to present to the server. Must also provide -cert option.
+-cname		Server name override when validating TLS certificate - useful for self signed certs.
+-skipTLS	Skip TLS client verification of the server's certificate chain and host name.
+-insecure	Use plaintext and insecure connection.
+-authority	Value to be used as the :authority pseudo-header. Only works if -insecure is used.
 
 -c  Number of requests to run concurrently.
     Total number of requests cannot be smaller than the concurrency level. Default is 50.
 -n  Number of requests to run. Default is 200.
 -q  Rate limit, in queries per second (QPS). Default is no rate limit.
 -t  Timeout for each request in seconds. Default is 20, use 0 for infinite.
--z  Duration of application to send requests. When duration is reached,
-	application stops and exits. If duration is specified, n is ignored.
-	Examples: -z 10s -z 3m.
+-z  Duration of application to send requests. When duration is reached, application stops and exits.
+    If duration is specified, n is ignored. Examples: -z 10s -z 3m.
 -x  Maximum duration of application to send requests with n setting respected.
     If duration is reached before n requests are completed, application stops and exits.
     Examples: -x 10s -x 3m.
 
 -d  The call data as stringified JSON.
     If the value is '@' then the request contents are read from stdin.
--D  Path for call data JSON file. For example, /home/user/file.json or ./file.json.
+-D  Path for call data JSON file. Examples: /home/user/file.json or ./file.json.
 -b  The call data comes as serialized binary message read from stdin.
 -B  Path for the call data as serialized binary message.
 -m  Request metadata as stringified JSON.
--M  Path for call metadata JSON file. For example, /home/user/metadata.json or ./metadata.json.
+-M  Path for call metadata JSON file. Examples: /home/user/metadata.json or ./metadata.json.
 
 -o  Output path. If none provided stdout is used.
 -O  Output type. If none provided, a summary is printed.
@@ -44,16 +51,13 @@ Options:
     "influx-summary" outputs the metrics summary as influxdb line protocol.
     "influx-details" outputs the metrics details as influxdb line protocol.
 
--i  Comma separated list of proto import paths. The current working directory and the directory
-    of the protocol buffer file are automatically added to the import list.
-
 -T  Connection timeout in seconds for the initial connection dial. Default is 10.
 -L  Keepalive time in seconds. Only used if present and above 0.
 
 -name  User specified name for the test.
 -tags  JSON representation of user-defined string tags.
 
--cpus  Number of used cpu cores. (default for current machine is 8 cores)
+-cpus  Number of used cpu cores.
 
 -v  Print the version.
 ```


### PR DESCRIPTION
Should address #55.

All security related options:

```
-cacert		File containing trusted root certificates for verifying the server.
-cert		File containing client certificate (public key), to present to the server. Must also provide -key option.
-key 		File containing client private key, to present to the server. Must also provide -cert option.
-cname		Server name override when validating TLS certificate - useful for self signed certs.
-skipTLS	Skip TLS client verification of the server's certificate chain and host name.
-insecure	Use plaintext and insecure connection.
-authority	Value to be used as the :authority pseudo-header. Only works if -insecure is used.
```

Breaking API changes with regards to `WithCertificate()`.
Adds new API functions for additional options.