### PR TITLE
Add stream interval

### DIFF
--- a/cmd/ghz/main.go
+++ b/cmd/ghz/main.go
@@ -102,6 +102,9 @@ Options:
 -m  Request metadata as stringified JSON.
 -M  Path for call metadata JSON file. Examples: /home/user/metadata.json or ./metadata.json.
 
+-si Stream interval duration. Spread stream sends by given amount. 
+    Only applies to client and bidi streaming calls. Example: 100ms
+
 -o  Output path. If none provided stdout is used.
 -O  Output type. If none provided, a summary is printed.
     "csv" outputs the response metrics in comma-separated values format.

--- a/cmd/ghz/main.go
+++ b/cmd/ghz/main.go
@@ -48,6 +48,7 @@ var (
 	binPath  = flag.String("B", "", "File path for the call data as serialized binary message.")
 	md       = flag.String("m", "", "Request metadata as stringified JSON.")
 	mdPath   = flag.String("M", "", "File path for call metadata JSON file. Examples: /home/user/metadata.json or ./metadata.json.")
+	si       = flag.Duration("si", 0, "Interval for stream requests between message sends.")
 
 	output = flag.String("o", "", "Output path. If none provided stdout is used.")
 	format = flag.String("O", "", "Output format. If none provided, a summary is printed.")
@@ -158,9 +159,9 @@ func main() {
 	}
 
 	// init / fix up durations
-	if cfg.X.Duration > 0 {
-		cfg.Z.Duration = cfg.X.Duration
-	} else if cfg.Z.Duration > 0 {
+	if cfg.X > 0 {
+		cfg.Z = cfg.X
+	} else if cfg.Z > 0 {
 		cfg.N = math.MaxInt32
 	}
 
@@ -180,13 +181,14 @@ func main() {
 		runner.WithTotalRequests(cfg.N),
 		runner.WithQPS(cfg.QPS),
 		runner.WithTimeout(time.Duration(cfg.Timeout)*time.Second),
-		runner.WithRunDuration(cfg.Z.Duration),
+		runner.WithRunDuration(time.Duration(cfg.Z)),
 		runner.WithDialTimeout(time.Duration(cfg.DialTimeout)*time.Second),
 		runner.WithKeepalive(time.Duration(cfg.KeepaliveTime)*time.Second),
 		runner.WithName(cfg.Name),
 		runner.WithCPUs(cfg.CPUs),
 		runner.WithMetadata(cfg.Metadata),
 		runner.WithTags(cfg.Tags),
+		runner.WithStreamInterval(time.Duration(cfg.SI)),
 	)
 
 	if strings.TrimSpace(cfg.MetadataPath) != "" {
@@ -306,8 +308,8 @@ func createConfigFromArgs() (*config, error) {
 		N:             *n,
 		C:             *c,
 		QPS:           *q,
-		Z:             duration{*z},
-		X:             duration{*x},
+		Z:             Duration(*z),
+		X:             Duration(*x),
 		Timeout:       *t,
 		Data:          dataObj,
 		DataPath:      *dataPath,
@@ -315,6 +317,7 @@ func createConfigFromArgs() (*config, error) {
 		BinDataPath:   *binPath,
 		Metadata:      &metadata,
 		MetadataPath:  *mdPath,
+		SI:            Duration(*si),
 		Output:        *output,
 		Format:        *format,
 		ImportPaths:   iPaths,

--- a/runner/data.go
+++ b/runner/data.go
@@ -45,6 +45,7 @@ func createPayloads(data string, mtd *desc.MethodDescriptor) (*dynamic.Message, 
 			if elems > 0 {
 				streamInput = make([]*dynamic.Message, elems)
 			}
+
 			for i, elem := range dataArray {
 				elemMsg := dynamic.NewMessage(md)
 				err := messageFromMap(elemMsg, &elem)

--- a/runner/options.go
+++ b/runner/options.go
@@ -46,6 +46,8 @@ type RunConfig struct {
 	dialTimeout   time.Duration
 	keepaliveTime time.Duration
 
+	streamInterval time.Duration
+
 	// data
 	data     []byte
 	binary   bool
@@ -405,6 +407,15 @@ func WithProtoset(protoset string) Option {
 	return func(o *RunConfig) error {
 		protoset = strings.TrimSpace(protoset)
 		o.protoset = protoset
+
+		return nil
+	}
+}
+
+// WithStreamInterval sets the stream interval
+func WithStreamInterval(d time.Duration) Option {
+	return func(o *RunConfig) error {
+		o.streamInterval = d
 
 		return nil
 	}

--- a/runner/requester.go
+++ b/runner/requester.go
@@ -269,6 +269,13 @@ func (b *Requester) makeClientStreamingRequest(ctx *context.Context, input *[]*d
 		}
 
 		payload := streamInput[counter]
+
+		var wait <-chan time.Time
+		if b.config.streamInterval > 0 {
+			wait = time.Tick(b.config.streamInterval)
+			<-wait
+		}
+
 		err = str.SendMsg(payload)
 		if err == io.EOF {
 			// We get EOF on send if the server says "go away"
@@ -310,6 +317,12 @@ func (b *Requester) makeBidiRequest(ctx *context.Context, input *[]*dynamic.Mess
 		}
 
 		payload := streamInput[counter]
+
+		var wait <-chan time.Time
+		if b.config.streamInterval > 0 {
+			wait = time.Tick(b.config.streamInterval)
+			<-wait
+		}
 		err = str.SendMsg(payload)
 		counter++
 	}

--- a/testdata/config.json
+++ b/testdata/config.json
@@ -1,7 +1,9 @@
 {
-  "x": "7s",
   "n": 5000,
   "c": 50,
+  "x": "7s",
+  "z": "12s",
+  "si": "500ms",
   "proto": "../../testdata/greeter.proto",
   "call": "helloworld.Greeter.SayHello",
   "d": {

--- a/testdata/config4.toml
+++ b/testdata/config4.toml
@@ -1,0 +1,21 @@
+n = 500
+c = 1
+x = "7s"
+z = "12s"
+si = "500ms"
+proto = "../../testdata/greeter.proto"
+call = "helloworld.Greeter.SayHelloBidi"
+host = "0.0.0.0:50051"
+insecure = true
+
+[[d]]
+name = "Bob 1 {{.TimestampUnix}}"
+[[d]]
+name = "Bob 2 {{.TimestampUnix}}"
+[[d]]
+name = "Bob 3 {{.TimestampUnix}}"
+[[d]]
+name = "Bob 4 {{.TimestampUnix}}"
+
+[m]
+rn = "{{.RequestNumber}}"

--- a/www/docs/options.md
+++ b/www/docs/options.md
@@ -82,7 +82,13 @@ Maximum duration of application to send requests with `n` setting respected. If 
 
 ### `-d`
 
-The call data as stringified JSON. If the value is `@` then the request contents are read from standard input (stdin). Example: `-d '{"name":"Bob"}'`. For client streaming or bi-directional calls we can accept a JSON array of messages, and each element representing a single message within the stream call. For example: `-d '[{"name":"Joe"},{"name":"Kate"},{"name":"Sara"}]'` can be used as input for a client streaming call. In case of streaming calls if a single object is given for data then the it is sent as every message.
+The call data as stringified JSON. If the value is `@` then the request contents are read from standard input (stdin). Example: `-d '{"name":"Bob"}'`. 
+
+For client streaming or bi-directional calls we can accept a JSON array of messages, and each element representing a single message within the stream call. For example: `-d '[{"name":"Joe"},{"name":"Kate"},{"name":"Sara"}]'` can be used as input for a client streaming or bidi call. In case of streaming calls if a single object is given for data then it is automatically converted to an array with single element. For example `-d '{"name":"Joe"}'` is equivalent to `-d '[{"name":"Joe"}]`.
+
+In case of client streaming we send all the messages in the input array and then we close and receive.
+
+In case of bidi we send all the messages in the array first and close the send portion; then read the messages from the server until EOF and then the call is finished.
 
 ### `-D`
 


### PR DESCRIPTION
Add stream interval `-si` duration argument as a wait interval between sends of individual messages in client streaming and bidi streaming calls.

For example 

```
...
-call helloworld.Greeter.SayHelloBidi \
-d '[{"name": "Bob Smith"},{"name": "Bob 2"},{"name": "Bob 3"},{"name": "Bob Smith4"},{"name": "Bob Smith5"},{"name": "Bob Smith 6"},{"name": "Bob Smith 7"}]' \
-name 'Greeter SayHello' \
-si 500ms \
...
```

will cause the stream sends for client streaming and bidi streaming calls to be spread by 100 ms.