### PR TITLE
Get ghz compliant with errcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ staticcheck:
 # Lint runs all linters. This is the main lint target to run.
 # TODO: add errcheck and staticcheck when the code is updated to pass them
 .PHONY: lint
-lint: golint
+lint: golint errcheck
 
 # Test runs go test on GO_PKGS. This does not produce code coverage.
 .PHONY: test

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,8 @@ require (
 	github.com/stretchr/testify v1.3.0
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4 // indirect
+	go.uber.org/atomic v1.3.2 // indirect
+	go.uber.org/multierr v1.1.0
 	golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc // indirect
 	golang.org/x/net v0.0.0-20190110200230-915654e7eabc
 	google.golang.org/grpc v1.17.0

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,10 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4 h1:gKMu1Bf6QINDnvyZuTaACm9ofY+PRh+5vFz4oxBZeF8=
 github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4/go.mod h1:50wTf68f99/Zt14pr046Tgt3Lp2vLyFZKzbFXTOabXw=
+go.uber.org/atomic v1.3.2 h1:2Oa65PReHzfn29GpvgsYwloV9AVFHPDk8tYxt2c2tr4=
+go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/multierr v1.1.0 h1:HoEmRHQPVSqub6w2z2d2EOVs2fjyFRGyofhKuyDq0QI=
+go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc h1:F5tKCVGp+MUAHhKp5MZtGqAlGX3+oCsiL1Q629FL90M=
 golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3 h1:x/bBzNauLQAlE3fLku/xy92Y8QwKX5HZymrMz2IiKFc=

--- a/internal/common.go
+++ b/internal/common.go
@@ -11,13 +11,15 @@ import (
 	"github.com/bojand/ghz/internal/helloworld"
 )
 
-// TestPort is the port
+// TestPort is the port.
 var TestPort string
 
-// TestLocalhost is the localhost
+// TestLocalhost is the localhost.
 var TestLocalhost string
 
-// StartServer starts server
+// StartServer starts the server.
+//
+// For testing only.
 func StartServer(secure bool) (*helloworld.Greeter, *grpc.Server, error) {
 	lis, err := net.Listen("tcp", ":0")
 	if err != nil {
@@ -44,7 +46,7 @@ func StartServer(secure bool) (*helloworld.Greeter, *grpc.Server, error) {
 	TestLocalhost = "localhost:" + TestPort
 
 	go func() {
-		s.Serve(lis)
+		_ = s.Serve(lis)
 	}()
 
 	return gs, s, err

--- a/web/database/database.go
+++ b/web/database/database.go
@@ -16,7 +16,9 @@ const dbName = "../test/test.db"
 
 // New creates a new wrapper for the gorm database framework.
 func New(dialect, connection string, log bool) (*Database, error) {
-	createDirectoryIfSqlite(dialect, connection)
+	if err := createDirectoryIfSqlite(dialect, connection); err != nil {
+		return nil, err
+	}
 
 	db, err := gorm.Open(dialect, connection)
 	if err != nil {
@@ -47,14 +49,15 @@ func New(dialect, connection string, log bool) (*Database, error) {
 	return &Database{DB: db}, nil
 }
 
-func createDirectoryIfSqlite(dialect string, connection string) {
+func createDirectoryIfSqlite(dialect string, connection string) error {
 	if dialect == "sqlite3" {
 		if _, err := os.Stat(filepath.Dir(connection)); os.IsNotExist(err) {
 			if err := os.MkdirAll(filepath.Dir(connection), 0777); err != nil {
-				panic(err)
+				return err
 			}
 		}
 	}
+	return nil
 }
 
 // Database is a wrapper for the gorm framework.
@@ -63,6 +66,6 @@ type Database struct {
 }
 
 // Close closes the gorm database connection.
-func (d *Database) Close() {
-	d.DB.Close()
+func (d *Database) Close() error {
+	return d.DB.Close()
 }


### PR DESCRIPTION
This PR does a few things:

- Get ghz compliant with errcheck by propagating all errors, and documenting those that are purposefully ignored.
- Remove all panics.
- Remove all calls to the `log` package. Having a library log with the global stdlib logger makes it not possible for users to do logging in their own way.
- Remove all calls outside of `cmd/` to `fmt.Print*` for the same reason.
- Add TODOS in the `Requester` where errors should be handled.
- Do some locking in the `Requester`. Probably better to do some more extensive connection management in the future, but this is a start.
- Other minor cleanups.
- My editor removes whitespace, so a lot of that done.

Note this adds calls to https://godoc.org/go.uber.org/multierr#Append, which is a super simple library to handle having multiple errors.