### PR TITLE
Add supported format to printer.Print

### DIFF
--- a/printer/printer.go
+++ b/printer/printer.go
@@ -26,6 +26,16 @@ type ReportPrinter struct {
 // Print the report using the given format
 // If format is "csv" detailed listing is printer in csv format.
 // Otherwise the summary of results is printed.
+//
+// Supported Format:
+//
+// 		summary
+// 		csv
+// 		json
+// 		pretty
+// 		html
+// 		influx-summary
+// 		influx-details
 func (rp *ReportPrinter) Print(format string) error {
 	if format == "" {
 		format = "summary"


### PR DESCRIPTION
@bojand please review

---

## Problem

It would be great to indicate a possible `format string` type for users.

Otherwise, users should look into the codebase and see the supported formats.

https://godoc.org/github.com/bojand/ghz/printer

Of course, you can guess them from CLI usage, but I think it is different and should be documented in the codebase as well.

## Expected Output

<img width="505" alt="Screen Shot 2019-10-02 at 15 26 39" src="https://user-images.githubusercontent.com/4186381/66022475-17f71780-e529-11e9-888e-596e72122690.png">
