### PR TITLE
Add Unix Nanosecond timestamp. Fixes #141.

### DIFF
--- a/runner/call_template_data.go
+++ b/runner/call_template_data.go
@@ -21,7 +21,8 @@ type callTemplateData struct {
 	IsClientStreaming  bool   // whether this call is client streaming
 	IsServerStreaming  bool   // whether this call is server streaming
 	Timestamp          string // timestamp of the call in RFC3339 format
-	TimestampUnix      int64  // timestamp of the call as unix time
+	TimestampUnix      int64  // timestamp of the call as unix time in seconds
+	TimestampUnixNano  int64  // timestamp of the call as unix time in nanoseconds
 }
 
 // newCallTemplateData returns new call template data
@@ -40,6 +41,7 @@ func newCallTemplateData(mtd *desc.MethodDescriptor, workerID string, reqNum int
 		IsServerStreaming:  mtd.IsServerStreaming(),
 		Timestamp:          now.Format(time.RFC3339),
 		TimestampUnix:      now.Unix(),
+		TimestampUnixNano:  now.UnixNano(),
 	}
 }
 

--- a/runner/call_template_data_test.go
+++ b/runner/call_template_data_test.go
@@ -26,6 +26,7 @@ func TestCallTemplateData_New(t *testing.T) {
 	assert.Equal(t, false, ctd.IsServerStreaming)
 	assert.NotEmpty(t, ctd.Timestamp)
 	assert.NotZero(t, ctd.TimestampUnix)
+	assert.NotZero(t, ctd.TimestampUnixNano)
 }
 
 func TestCallTemplateData_ExecuteData(t *testing.T) {

--- a/www/docs/calldata.md
+++ b/www/docs/calldata.md
@@ -39,8 +39,11 @@ type callTemplateData struct {
 	// timestamp of the call in RFC3339 format
 	Timestamp          string
 
-	// timestamp of the call as unix time
+	// timestamp of the call as unix time in seconds
 	TimestampUnix      int64
+
+	// timestamp of the call as unix time in nanoseconds
+	TimestampUnixNano      int64
 }
 ```
 


### PR DESCRIPTION
Add TimestampUnixNano to call data as timestamp of the call as unix time in nanoseconds. Fixes #141.