### PR TITLE
Add WithConfig options for runner

### DIFF
--- a/runner/config.go
+++ b/runner/config.go
@@ -1,4 +1,4 @@
-package main
+package runner
 
 import (
 	"encoding/json"
@@ -30,7 +30,7 @@ func (d Duration) String() string {
 }
 
 // Config for the run.
-type config struct {
+type Config struct {
 	Proto           string             `json:"proto" toml:"proto" yaml:"proto"`
 	Protoset        string             `json:"protoset" toml:"protoset" yaml:"protoset"`
 	Call            string             `json:"call" toml:"call" yaml:"call" required:"true"`
@@ -69,8 +69,8 @@ type config struct {
 
 // UnmarshalJSON is our custom implementation to handle the Duration fields
 // and validate data
-func (c *config) UnmarshalJSON(data []byte) error {
-	type Alias config
+func (c *Config) UnmarshalJSON(data []byte) error {
+	type Alias Config
 	aux := &struct {
 		Z       string `json:"z"`
 		X       string `json:"x"`
@@ -131,8 +131,8 @@ func (c *config) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalJSON is our custom implementation to handle the Duration fields
-func (c config) MarshalJSON() ([]byte, error) {
-	type Alias config
+func (c Config) MarshalJSON() ([]byte, error) {
+	type Alias Config
 	return json.Marshal(&struct {
 		*Alias
 		Z       string `json:"z"`

--- a/runner/options.go
+++ b/runner/options.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -65,6 +66,57 @@ type RunConfig struct {
 
 // Option controls some aspect of run
 type Option func(*RunConfig) error
+
+// WithConfigFromFile uses a configuration JSON file to populate the RunConfig
+//  WithConfig("config.json")
+func WithConfigFromFile(file string) Option {
+	return func(o *RunConfig) error {
+		data, err := ioutil.ReadFile(file)
+		if err != nil {
+			return fmt.Errorf("read config from file: %w", err)
+		}
+		var config Config
+		if err := json.Unmarshal(data, &config); err != nil {
+			return fmt.Errorf("unmarshal config: %w", err)
+		}
+		for _, option := range fromConfig(&config) {
+			if err := option(o); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// WithConfigFromReader uses a reader containing JSON data to populate the RunConfig
+// See also: WithConfigFromFile
+func WithConfigFromReader(reader io.Reader) Option {
+	return func(o *RunConfig) error {
+		var config Config
+		if err := json.NewDecoder(reader).Decode(&config); err != nil {
+			return fmt.Errorf("unmarshal config: %w", err)
+		}
+		for _, option := range fromConfig(&config) {
+			if err := option(o); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// WithConfig uses the configuration to populate the RunConfig
+// See also: WithConfigFromFile, WithConfigFromReader
+func WithConfig(c *Config) Option {
+	return func(o *RunConfig) error {
+		for _, option := range fromConfig(c) {
+			if err := option(o); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
 
 // WithCertificate specifies the certificate options for the run
 //	WithCertificate("client.crt", "client.key")
@@ -540,4 +592,64 @@ func createClientTransportCredentials(skipVerify bool, cacertFile, clientCertFil
 	}
 
 	return credentials.NewTLS(&tlsConf), nil
+}
+
+func fromConfig(cfg *Config) []Option {
+	// set up all the options
+	options := make([]Option, 0, 17)
+
+	options = append(options,
+		WithProtoFile(cfg.Proto, cfg.ImportPaths),
+		WithProtoset(cfg.Protoset),
+		WithRootCertificate(cfg.RootCert),
+		WithCertificate(cfg.Cert, cfg.Key),
+		WithServerNameOverride(cfg.CName),
+		WithSkipTLSVerify(cfg.SkipTLSVerify),
+		WithInsecure(cfg.Insecure),
+		WithAuthority(cfg.Authority),
+		WithConcurrency(cfg.C),
+		WithTotalRequests(cfg.N),
+		WithQPS(cfg.QPS),
+		WithTimeout(time.Duration(cfg.Timeout)),
+		WithRunDuration(time.Duration(cfg.Z)),
+		WithDialTimeout(time.Duration(cfg.DialTimeout)),
+		WithKeepalive(time.Duration(cfg.KeepaliveTime)),
+		WithName(cfg.Name),
+		WithCPUs(cfg.CPUs),
+		WithMetadata(cfg.Metadata),
+		WithTags(cfg.Tags),
+		WithStreamInterval(time.Duration(cfg.SI)),
+		WithReflectionMetadata(cfg.ReflectMetadata),
+		WithConnections(cfg.Connections),
+		func(o *RunConfig) error {
+			o.call = cfg.Call
+			return nil
+		},
+		func(o *RunConfig) error {
+			o.host = cfg.Host
+			return nil
+		},
+	)
+
+	if strings.TrimSpace(cfg.MetadataPath) != "" {
+		options = append(options, WithMetadataFromFile(strings.TrimSpace(cfg.MetadataPath)))
+	}
+
+	// data
+	if dataStr, ok := cfg.Data.(string); ok && dataStr == "@" {
+		options = append(options, WithDataFromReader(os.Stdin))
+	} else if strings.TrimSpace(cfg.DataPath) != "" {
+		options = append(options, WithDataFromFile(strings.TrimSpace(cfg.DataPath)))
+	} else {
+		options = append(options, WithData(cfg.Data))
+	}
+
+	// or binary data
+	if len(cfg.BinData) > 0 {
+		options = append(options, WithBinaryData(cfg.BinData))
+	}
+	if len(cfg.BinDataPath) > 0 {
+		options = append(options, WithBinaryDataFromFile(cfg.BinDataPath))
+	}
+	return options
 }

--- a/runner/options_test.go
+++ b/runner/options_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"encoding/json"
 	"os"
 	"runtime"
 	"testing"
@@ -358,5 +359,60 @@ func TestRunConfig_newRunConfig(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Nil(t, c)
+	})
+
+	t.Run("with config", func(t *testing.T) {
+		filename := "../testdata/config.json"
+		t.Run("from file", func(t *testing.T) {
+			c, err := newConfig("", "",
+				WithConfigFromFile(filename))
+			assert.Nil(t, err)
+			assert.Equal(t, "helloworld.Greeter.SayHello", c.call)
+			assert.Equal(t, "0.0.0.0:50051", c.host)
+			assert.Equal(t, "../../testdata/greeter.proto", c.proto)
+			assert.Equal(t, []string{"../../testdata", "."}, c.importPaths)
+			assert.Equal(t, 5000, c.n)
+			assert.Equal(t, 50, c.c)
+			assert.Equal(t, 12*time.Second, c.z)
+			assert.Equal(t, 500*time.Millisecond, c.streamInterval)
+			assert.Equal(t, []byte(`{"name":"Bob {{.TimestampUnix}}"}`), c.data)
+			assert.Equal(t, []byte(`{"rn":"{{.RequestNumber}}"}`), c.metadata)
+			assert.Equal(t, true, c.insecure)
+		})
+		file, _ := os.Open(filename)
+		defer file.Close()
+		t.Run("from reader", func(t *testing.T) {
+			c, err := newConfig("call", "localhost:50050",
+				WithConfigFromReader(file))
+			assert.Nil(t, err)
+			assert.Equal(t, "helloworld.Greeter.SayHello", c.call)
+			assert.Equal(t, "0.0.0.0:50051", c.host)
+			assert.Equal(t, "../../testdata/greeter.proto", c.proto)
+			assert.Equal(t, []string{"../../testdata", "."}, c.importPaths)
+			assert.Equal(t, 5000, c.n)
+			assert.Equal(t, 50, c.c)
+			assert.Equal(t, 12*time.Second, c.z)
+			assert.Equal(t, 500*time.Millisecond, c.streamInterval)
+			assert.Equal(t, []byte(`{"name":"Bob {{.TimestampUnix}}"}`), c.data)
+			assert.Equal(t, []byte(`{"rn":"{{.RequestNumber}}"}`), c.metadata)
+			assert.Equal(t, true, c.insecure)
+		})
+		file, _ = os.Open(filename)
+		var config Config
+		_ = json.NewDecoder(file).Decode(&config)
+		c, err := newConfig("call", "localhost:50050",
+			WithConfig(&config))
+		assert.Nil(t, err)
+		assert.Equal(t, "helloworld.Greeter.SayHello", c.call)
+		assert.Equal(t, "0.0.0.0:50051", c.host)
+		assert.Equal(t, "../../testdata/greeter.proto", c.proto)
+		assert.Equal(t, []string{"../../testdata", "."}, c.importPaths)
+		assert.Equal(t, 5000, c.n)
+		assert.Equal(t, 50, c.c)
+		assert.Equal(t, 12*time.Second, c.z)
+		assert.Equal(t, 500*time.Millisecond, c.streamInterval)
+		assert.Equal(t, []byte(`{"name":"Bob {{.TimestampUnix}}"}`), c.data)
+		assert.Equal(t, []byte(`{"rn":"{{.RequestNumber}}"}`), c.metadata)
+		assert.Equal(t, true, c.insecure)
 	})
 }


### PR DESCRIPTION
I prefer to use config files for configuring calls, but also like to use this as a library. Thus I added `WithConfig*` options for the runner. I thought I'd create a PR for it in case this is something more people would like to use.