### PR TITLE
Add template functions

### DIFF
--- a/runner/call_template_data_test.go
+++ b/runner/call_template_data_test.go
@@ -1,9 +1,13 @@
 package runner
 
 import (
+	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/bojand/ghz/protodesc"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -101,17 +105,17 @@ func TestCallTemplateData_ExecuteMetadata(t *testing.T) {
 	}{
 		{"no template",
 			`{"trace_id":"asdf"}`,
-			&map[string]string{"trace_id": "asdf"},
+			map[string]string{"trace_id": "asdf"},
 			false,
 		},
 		{"with template",
 			`{"trace_id":"{{.RequestNumber}} asdf {{.FullyQualifiedName}} {{.MethodName}} {{.ServiceName}} {{.InputName}} {{.OutputName}} {{.IsClientStreaming}} {{.IsServerStreaming}}"}`,
-			&map[string]string{"trace_id": "200 asdf helloworld.Greeter.SayHello SayHello Greeter HelloRequest HelloReply false false"},
+			map[string]string{"trace_id": "200 asdf helloworld.Greeter.SayHello SayHello Greeter HelloRequest HelloReply false false"},
 			false,
 		},
 		{"with unknown action",
 			`{"trace_id":"asdf {{.Something}} {{.MethodName}} bob"}`,
-			&map[string]string{"trace_id": "asdf {{.Something}} {{.MethodName}} bob"},
+			map[string]string{"trace_id": "asdf {{.Something}} {{.MethodName}} bob"},
 			false,
 		},
 	}
@@ -128,4 +132,132 @@ func TestCallTemplateData_ExecuteMetadata(t *testing.T) {
 			assert.Equal(t, tt.expected, r)
 		})
 	}
+}
+
+func TestCallTemplateData_ExecuteFuncs(t *testing.T) {
+	md, err := protodesc.GetMethodDescFromProto("helloworld.Greeter/SayHello", "../testdata/greeter.proto", []string{})
+	assert.NoError(t, err)
+	assert.NotNil(t, md)
+
+	ctd := newCallTemplateData(md, "worker_id_123", 200)
+
+	assert.NotNil(t, ctd)
+
+	t.Run("newUUID", func(t *testing.T) {
+
+		// no template
+		r, err := ctd.executeData(`{"trace_id":"asdf"}`)
+		assert.NoError(t, err)
+		assert.Equal(t, `{"trace_id":"asdf"}`, string(r))
+
+		rm, err := ctd.executeMetadata(`{"trace_id":"asdf"}`)
+		assert.NoError(t, err)
+		assert.Equal(t, map[string]string{"trace_id": "asdf"}, rm)
+
+		// new uuid
+		r, err = ctd.executeData(`{"trace_id":"{{newUUID}}"}`)
+		assert.NoError(t, err)
+		rs := strings.Replace(string(r), `{"trace_id":"`, "", -1)
+		rs = strings.Replace(rs, `"}`, "", -1)
+		assert.NotEmpty(t, rs)
+		parsed, err := uuid.Parse(rs)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, parsed)
+
+		rm2, err := ctd.executeMetadata(`{"trace_id":"{{newUUID}}"}`)
+		assert.NoError(t, err)
+		rs2 := rm2["trace_id"]
+		assert.NotEmpty(t, rs)
+		assert.NotEqual(t, rs, rs2)
+		parsed, err = uuid.Parse(rs2)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, parsed)
+
+		rm3, err := ctd.executeMetadata(`{"span_id":"{{newUUID}}","trace_id":"{{newUUID}}"}`)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, rs)
+		assert.NotEqual(t, rm3["span_id"], rs2)
+		assert.NotEqual(t, rm3["span_id"], rs)
+		assert.NotEqual(t, rm3["trace_id"], rs2)
+		assert.NotEqual(t, rm3["trace_id"], rs)
+		assert.NotEqual(t, rm3["trace_id"], rm3["span_id"])
+		parsed, err = uuid.Parse(rm3["span_id"])
+		assert.NoError(t, err)
+		assert.NotEmpty(t, parsed)
+		parsed, err = uuid.Parse(rm3["trace_id"])
+		assert.NoError(t, err)
+		assert.NotEmpty(t, parsed)
+
+		b, _ := json.Marshal(rm3)
+		fmt.Println(string(b))
+
+		r, err = ctd.executeData(`{"order_id":"{{newUUID}}", "item_id":"{{newUUID}}", "sku":"{{randomString 8 }}", "product_name":"{{randomString 0}}"}`)
+		fmt.Println(string(r))
+	})
+
+	t.Run("randomString", func(t *testing.T) {
+
+		// no template
+		r, err := ctd.executeData(`{"trace_id":"asdf"}`)
+		assert.NoError(t, err)
+		assert.Equal(t, `{"trace_id":"asdf"}`, string(r))
+
+		rm, err := ctd.executeMetadata(`{"trace_id":"asdf"}`)
+		assert.NoError(t, err)
+		assert.Equal(t, map[string]string{"trace_id": "asdf"}, rm)
+
+		// default length when 0
+		r, err = ctd.executeData(`{"trace_id":"{{randomString 0}}"}`)
+		assert.NoError(t, err)
+		rs := strings.Replace(string(r), `{"trace_id":"`, "", -1)
+		rs = strings.Replace(rs, `"}`, "", -1)
+		assert.NotEmpty(t, rs)
+		assert.True(t, len(rs) >= 2)
+		assert.True(t, len(rs) <= 16)
+
+		// default length when -1
+		r, err = ctd.executeData(`{"trace_id":"{{randomString -1}}"}`)
+		assert.NoError(t, err)
+		rs2 := strings.Replace(string(r), `{"trace_id":"`, "", -1)
+		rs2 = strings.Replace(rs2, `"}`, "", -1)
+		assert.NotEmpty(t, rs2)
+		assert.NotEqual(t, rs, rs2)
+		assert.True(t, len(rs2) >= 2)
+		assert.True(t, len(rs2) <= 16)
+
+		// specific length
+		r, err = ctd.executeData(`{"trace_id":"{{randomString 10}}"}`)
+		assert.NoError(t, err)
+		rs = strings.Replace(string(r), `{"trace_id":"`, "", -1)
+		rs = strings.Replace(rs, `"}`, "", -1)
+		assert.NotEmpty(t, rs)
+		assert.Len(t, rs, 10)
+
+		rm, err = ctd.executeMetadata(`{"trace_id":"{{randomString 0}}"}`)
+		assert.NoError(t, err)
+		assert.True(t, len(rm["trace_id"]) >= 2)
+		assert.True(t, len(rm["trace_id"]) <= 16)
+
+		rm, err = ctd.executeMetadata(`{"span_id":"{{randomString -1}}","trace_id":"{{randomString 0}}"}`)
+		assert.NoError(t, err)
+		assert.True(t, len(rm["trace_id"]) >= 2)
+		assert.True(t, len(rm["trace_id"]) <= 16)
+		assert.True(t, len(rm["span_id"]) >= 2)
+		assert.True(t, len(rm["span_id"]) <= 16)
+		assert.NotEqual(t, rm["trace_id"], rm["span_id"])
+
+		b, _ := json.Marshal(rm)
+		fmt.Println(string(b))
+
+		rm, err = ctd.executeMetadata(`{"span_id":"{{randomString 12}}","trace_id":"{{randomString 12}}"}`)
+		assert.NoError(t, err)
+		assert.Len(t, rm["trace_id"], 12)
+		assert.Len(t, rm["span_id"], 12)
+		assert.NotEqual(t, rm["trace_id"], rs)
+		assert.NotEqual(t, rm["trace_id"], rs2)
+		assert.NotEqual(t, rm["trace_id"], rm["span_id"])
+
+		b, _ = json.Marshal(rm)
+		fmt.Println(string(b))
+	})
 }

--- a/runner/options.go
+++ b/runner/options.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/pkg/errors"
@@ -70,6 +71,8 @@ type RunConfig struct {
 	cpus      int
 	tags      []byte
 	skipFirst int
+
+	funcs template.FuncMap
 }
 
 // Option controls some aspect of run
@@ -541,6 +544,15 @@ func WithLogger(log Logger) Option {
 	return func(o *RunConfig) error {
 		o.log = log
 		o.hasLog = true
+
+		return nil
+	}
+}
+
+// WithTemplateFuncs adds additional tempalte functions
+func WithTemplateFuncs(funcMap template.FuncMap) Option {
+	return func(o *RunConfig) error {
+		o.funcs = funcMap
 
 		return nil
 	}

--- a/runner/worker.go
+++ b/runner/worker.go
@@ -65,7 +65,7 @@ func (w *Worker) makeRequest() error {
 
 	reqNum := atomic.AddInt64(w.reqCounter, 1)
 
-	ctd := newCallTemplateData(w.mtd, w.workerID, reqNum)
+	ctd := newCallTemplateData(w.mtd, w.config.funcs, w.workerID, reqNum)
 
 	var inputs []*dynamic.Message
 	var err error
@@ -88,7 +88,7 @@ func (w *Worker) makeRequest() error {
 	}
 
 	var reqMD *metadata.MD
-	if mdMap != nil && len(mdMap) > 0 {
+	if len(mdMap) > 0 {
 		md := metadata.New(mdMap)
 		reqMD = &md
 	} else {

--- a/runner/worker.go
+++ b/runner/worker.go
@@ -88,8 +88,8 @@ func (w *Worker) makeRequest() error {
 	}
 
 	var reqMD *metadata.MD
-	if mdMap != nil && len(*mdMap) > 0 {
-		md := metadata.New(*mdMap)
+	if mdMap != nil && len(mdMap) > 0 {
+		md := metadata.New(mdMap)
 		reqMD = &md
 	} else {
 		reqMD = &metadata.MD{}

--- a/www/docs/calldata.md
+++ b/www/docs/calldata.md
@@ -53,6 +53,16 @@ type callTemplateData struct {
 }
 ```
 
+**Functions**
+
+There are also two template functions available:
+
+`newUUID` - Generates a new UUID for each invocation.
+
+`randomString` - Generates a new random string for each incovation. Accepts a length parameter. If the argument is `<= 0` then a ranom string is generated with a random length between length of `2` and `16`.
+
+**Examples**
+
 This can be useful to inject variable information into the message data JSON or metadata JSON payloads for each request, such as timestamp or unique request number. For example:
 
 ```sh
@@ -66,6 +76,21 @@ Would result in server getting the following metadata map represented here in JS
   "user-agent": "grpc-go/1.11.1",
   "request-id": "1",
   "timestamp": "1544890252"
+}
+```
+
+```sh
+-d '{"order_id":"{{newUUID}}", "item_id":"{{newUUID}}", "sku":"{{randomString 8 }}", "product_name":"{{ranomdString 0}}"}'
+```
+
+Would result in data with JSON representation:
+
+```json
+{
+  "order_id": "3974e7b3-5946-4df5-bed3-8c3dc9a0be19",
+  "item_id": "cd9c2604-cd9b-43a8-9cbb-d1ad26ca93a4",
+  "sku": "HlFTAxcm",
+  "product_name": "xg3NEC"
 }
 ```
 


### PR DESCRIPTION
Adds template functions:

`newUUID` - Generates a new UUID for each invocation.

`randomString` - Generates a new random string for each incovation. Accepts a length parameter. If the argument is `<= 0` then a ranom string is generated with a random length between length of `2` and `16`.

Example usage with data:

```sh
-d '{"order_id":"{{newUUID}}", "item_id":"{{newUUID}}", "sku":"{{randomString 8 }}", "product_name":"{{ranomdString 0}}"}'
```

Would result in data with JSON representation:

```json
{
  "order_id": "3974e7b3-5946-4df5-bed3-8c3dc9a0be19",
  "item_id": "cd9c2604-cd9b-43a8-9cbb-d1ad26ca93a4",
  "sku": "HlFTAxcm",
  "product_name": "xg3NEC"
}
```

Also adds `WithTemplateFuncs()` API option.

Addresses #213.