### PR TITLE
Fix file config API options

### DIFF
--- a/cmd/ghz/main.go
+++ b/cmd/ghz/main.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"math"
 	"os"
 	"runtime"
 	"strconv"
@@ -218,12 +217,6 @@ func main() {
 		kingpin.FatalIfError(err, "")
 	}
 
-	// init / fix up durations
-	if cfg.X > 0 {
-		cfg.Z = cfg.X
-	} else if cfg.Z > 0 {
-		cfg.N = math.MaxInt32
-	}
 	var logger *zap.SugaredLogger
 
 	options := []runner.Option{runner.WithConfig(&cfg)}

--- a/testdata/config5.toml
+++ b/testdata/config5.toml
@@ -1,0 +1,13 @@
+total = 5000
+concurrency = 40
+skipFirst = 100
+proto = "../../testdata/greeter.proto"
+call = "helloworld.Greeter.SayHello"
+host = "0.0.0.0:50051"
+insecure = true
+
+[data]
+name = "Bob {{.TimestampUnix}}"
+
+[metadata]
+rn = "{{.RequestNumber}}"


### PR DESCRIPTION
- Use `LoadConfig` in API to properly read in config
- Perform correct test duration init and setup in package API functions instead of just in cli