### PR TITLE
Exposes runner.NewRequester publicly

### DIFF
--- a/runner/requester.go
+++ b/runner/requester.go
@@ -60,7 +60,8 @@ type Requester struct {
 	lock       sync.Mutex
 }
 
-func newRequester(c *RunConfig) (*Requester, error) {
+// NewRequester creates a new requestor from the passed RunConfig
+func NewRequester(c *RunConfig) (*Requester, error) {
 
 	var err error
 	var mtd *desc.MethodDescriptor

--- a/runner/run.go
+++ b/runner/run.go
@@ -28,7 +28,7 @@ func Run(call, host string, options ...Option) (*Report, error) {
 	runtime.GOMAXPROCS(c.cpus)
 	defer runtime.GOMAXPROCS(oldCPUs)
 
-	reqr, err := newRequester(c)
+	reqr, err := NewRequester(c)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Per https://github.com/bojand/ghz/issues/223 this PR adds the ability to create a `runner.Requester` without having to call `runner.Run` which has the issue that it blocks when called.  

Being able to create and have direct access to the `runner.Requester` means that a user can setup differing ways of canceling runs beyond what is possible with `runner.Run` as they will have direct access to `runner.Requester.Stop(...)`.

A potential alternative to this is exposing a new option that takes a channel that can be used to listen for a cancel signal, although that seems like a bit more complicated approach than this.