### PR TITLE
[feature] adds a binary option

### DIFF
--- a/runner/data.go
+++ b/runner/data.go
@@ -118,7 +118,12 @@ func createPayloadsFromBinCountDelimited(binData []byte, mtd *desc.MethodDescrip
 	return inputs, nil
 }
 
-func createPayloadsFromBin(binData []byte, mtd *desc.MethodDescriptor) ([]*dynamic.Message, error) {
+func createPayloadsFromBin(binData []byte, mtd *desc.MethodDescriptor, dataFunc func(method string) []byte) ([]*dynamic.Message, error) {
+
+	if dataFunc != nil {
+		binData = dataFunc(mtd.GetName())
+	}
+
 	inputs, err := createPayloadsFromBinCountDelimited(binData, mtd)
 
 	if err == nil && len(inputs) > 0 {

--- a/runner/data_test.go
+++ b/runner/data_test.go
@@ -229,7 +229,7 @@ func TestData_createPayloads(t *testing.T) {
 		binData, err := proto.Marshal(msg1)
 		assert.NoError(t, err)
 
-		inputs, err := createPayloadsFromBin(binData, mtdUnary)
+		inputs, err := createPayloadsFromBin(binData, mtdUnary, nil)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, inputs)
@@ -247,7 +247,7 @@ func TestData_createPayloads(t *testing.T) {
 		_ = buf.EncodeMessage(msg1)
 		_ = buf.EncodeMessage(msg2)
 
-		inputs, err := createPayloadsFromBin(buf.Bytes(), mtdUnary)
+		inputs, err := createPayloadsFromBin(buf.Bytes(), mtdUnary, nil)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, inputs)
@@ -258,7 +258,7 @@ func TestData_createPayloads(t *testing.T) {
 
 	t.Run("on empty binary data returns empty slice", func(t *testing.T) {
 		buf := make([]byte, 0)
-		inputs, err := createPayloadsFromBin(buf, mtdUnary)
+		inputs, err := createPayloadsFromBin(buf, mtdUnary, nil)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, inputs)

--- a/runner/options.go
+++ b/runner/options.go
@@ -58,7 +58,11 @@ type RunConfig struct {
 	streamInterval time.Duration
 
 	// data
-	data     []byte
+	data []byte
+
+	// data func
+	dataFunc     func(method string) []byte
+
 	binary   bool
 	metadata []byte
 	rmd      map[string]string
@@ -294,6 +298,16 @@ func WithKeepalive(k time.Duration) Option {
 func WithBinaryData(data []byte) Option {
 	return func(o *RunConfig) error {
 		o.data = data
+		o.binary = true
+
+		return nil
+	}
+}
+
+// WithBinaryDataFunc specifies the binary data func which will be called on each request
+func WithBinaryDataFunc(data func(string)[]byte) Option {
+	return func(o *RunConfig) error {
+		o.dataFunc = data
 		o.binary = true
 
 		return nil


### PR DESCRIPTION
# What it does
- Adds a new option. A binary function which get's called every-time a new request is done. 
- Removed the cache for binary data. The cache can be reintroduced by checking for that option 

# Motivation
- Making requests truly randomised to mirror more proper workload.