### PR TITLE
[RFC] [WIP] Support for specifying an array of metadata objects to use for the outgoing requests

### DIFF
--- a/runner/config.go
+++ b/runner/config.go
@@ -56,44 +56,44 @@ func (d Duration) MarshalJSON() ([]byte, error) {
 
 // Config for the run.
 type Config struct {
-	Proto             string            `json:"proto" toml:"proto" yaml:"proto"`
-	Protoset          string            `json:"protoset" toml:"protoset" yaml:"protoset"`
-	Call              string            `json:"call" toml:"call" yaml:"call"`
-	RootCert          string            `json:"cacert" toml:"cacert" yaml:"cacert"`
-	Cert              string            `json:"cert" toml:"cert" yaml:"cert"`
-	Key               string            `json:"key" toml:"key" yaml:"key"`
-	SkipTLSVerify     bool              `json:"skipTLS" toml:"skipTLS" yaml:"skipTLS"`
-	SkipFirst         uint              `json:"skipFirst" toml:"skipFirst" yaml:"skipFirst"`
-	CName             string            `json:"cname" toml:"cname" yaml:"cname"`
-	Authority         string            `json:"authority" toml:"authority" yaml:"authority"`
-	Insecure          bool              `json:"insecure,omitempty" toml:"insecure,omitempty" yaml:"insecure,omitempty"`
-	N                 uint              `json:"total" toml:"total" yaml:"total" default:"200"`
-	C                 uint              `json:"concurrency" toml:"concurrency" yaml:"concurrency" default:"50"`
-	Connections       uint              `json:"connections" toml:"connections" yaml:"connections" default:"1"`
-	QPS               uint              `json:"qps" toml:"qps" yaml:"qps"`
-	Z                 Duration          `json:"duration" toml:"duration" yaml:"duration"`
-	ZStop             string            `json:"duration-stop" toml:"duration-stop" yaml:"duration-stop" default:"close"`
-	X                 Duration          `json:"max-duration" toml:"max-duration" yaml:"max-duration"`
-	Timeout           Duration          `json:"timeout" toml:"timeout" yaml:"timeout" default:"20s"`
-	Data              interface{}       `json:"data,omitempty" toml:"data,omitempty" yaml:"data,omitempty"`
-	DataPath          string            `json:"data-file" toml:"data-file" yaml:"data-file"`
-	BinData           []byte            `json:"-" toml:"-" yaml:"-"`
-	BinDataPath       string            `json:"binary-file" toml:"binary-file" yaml:"binary-file"`
-	Metadata          map[string]string `json:"metadata,omitempty" toml:"metadata,omitempty" yaml:"metadata,omitempty"`
-	MetadataPath      string            `json:"metadata-file" toml:"metadata-file" yaml:"metadata-file"`
-	SI                Duration          `json:"stream-interval" toml:"stream-interval" yaml:"stream-interval"`
-	Output            string            `json:"output" toml:"output" yaml:"output"`
-	Format            string            `json:"format" toml:"format" yaml:"format" default:"summary"`
-	DialTimeout       Duration          `json:"connect-timeout" toml:"connect-timeout" yaml:"connect-timeout" default:"10s"`
-	KeepaliveTime     Duration          `json:"keepalive" toml:"keepalive" yaml:"keepalive"`
-	CPUs              uint              `json:"cpus" toml:"cpus" yaml:"cpus"`
-	ImportPaths       []string          `json:"import-paths,omitempty" toml:"import-paths,omitempty" yaml:"import-paths,omitempty"`
-	Name              string            `json:"name,omitempty" toml:"name,omitempty" yaml:"name,omitempty"`
-	Tags              map[string]string `json:"tags,omitempty" toml:"tags,omitempty" yaml:"tags,omitempty"`
-	ReflectMetadata   map[string]string `json:"reflect-metadata,omitempty" toml:"reflect-metadata,omitempty" yaml:"reflect-metadata,omitempty"`
-	Debug             string            `json:"debug,omitempty" toml:"debug,omitempty" yaml:"debug,omitempty"`
-	Host              string            `json:"host" toml:"host" yaml:"host"`
-	EnableCompression bool              `json:"enable-compression,omitempty" toml:"enable-compression,omitempty" yaml:"enable-compression,omitempty"`
+	Proto             string              `json:"proto" toml:"proto" yaml:"proto"`
+	Protoset          string              `json:"protoset" toml:"protoset" yaml:"protoset"`
+	Call              string              `json:"call" toml:"call" yaml:"call"`
+	RootCert          string              `json:"cacert" toml:"cacert" yaml:"cacert"`
+	Cert              string              `json:"cert" toml:"cert" yaml:"cert"`
+	Key               string              `json:"key" toml:"key" yaml:"key"`
+	SkipTLSVerify     bool                `json:"skipTLS" toml:"skipTLS" yaml:"skipTLS"`
+	SkipFirst         uint                `json:"skipFirst" toml:"skipFirst" yaml:"skipFirst"`
+	CName             string              `json:"cname" toml:"cname" yaml:"cname"`
+	Authority         string              `json:"authority" toml:"authority" yaml:"authority"`
+	Insecure          bool                `json:"insecure,omitempty" toml:"insecure,omitempty" yaml:"insecure,omitempty"`
+	N                 uint                `json:"total" toml:"total" yaml:"total" default:"200"`
+	C                 uint                `json:"concurrency" toml:"concurrency" yaml:"concurrency" default:"50"`
+	Connections       uint                `json:"connections" toml:"connections" yaml:"connections" default:"1"`
+	QPS               uint                `json:"qps" toml:"qps" yaml:"qps"`
+	Z                 Duration            `json:"duration" toml:"duration" yaml:"duration"`
+	ZStop             string              `json:"duration-stop" toml:"duration-stop" yaml:"duration-stop" default:"close"`
+	X                 Duration            `json:"max-duration" toml:"max-duration" yaml:"max-duration"`
+	Timeout           Duration            `json:"timeout" toml:"timeout" yaml:"timeout" default:"20s"`
+	Data              interface{}         `json:"data,omitempty" toml:"data,omitempty" yaml:"data,omitempty"`
+	DataPath          string              `json:"data-file" toml:"data-file" yaml:"data-file"`
+	BinData           []byte              `json:"-" toml:"-" yaml:"-"`
+	BinDataPath       string              `json:"binary-file" toml:"binary-file" yaml:"binary-file"`
+	Metadata          []map[string]string `json:"metadata,omitempty" toml:"metadata,omitempty" yaml:"metadata,omitempty"`
+	MetadataPath      string              `json:"metadata-file" toml:"metadata-file" yaml:"metadata-file"`
+	SI                Duration            `json:"stream-interval" toml:"stream-interval" yaml:"stream-interval"`
+	Output            string              `json:"output" toml:"output" yaml:"output"`
+	Format            string              `json:"format" toml:"format" yaml:"format" default:"summary"`
+	DialTimeout       Duration            `json:"connect-timeout" toml:"connect-timeout" yaml:"connect-timeout" default:"10s"`
+	KeepaliveTime     Duration            `json:"keepalive" toml:"keepalive" yaml:"keepalive"`
+	CPUs              uint                `json:"cpus" toml:"cpus" yaml:"cpus"`
+	ImportPaths       []string            `json:"import-paths,omitempty" toml:"import-paths,omitempty" yaml:"import-paths,omitempty"`
+	Name              string              `json:"name,omitempty" toml:"name,omitempty" yaml:"name,omitempty"`
+	Tags              map[string]string   `json:"tags,omitempty" toml:"tags,omitempty" yaml:"tags,omitempty"`
+	ReflectMetadata   map[string]string   `json:"reflect-metadata,omitempty" toml:"reflect-metadata,omitempty" yaml:"reflect-metadata,omitempty"`
+	Debug             string              `json:"debug,omitempty" toml:"debug,omitempty" yaml:"debug,omitempty"`
+	Host              string              `json:"host" toml:"host" yaml:"host"`
+	EnableCompression bool                `json:"enable-compression,omitempty" toml:"enable-compression,omitempty" yaml:"enable-compression,omitempty"`
 }
 
 func checkData(data interface{}) error {

--- a/runner/options.go
+++ b/runner/options.go
@@ -391,7 +391,7 @@ func WithMetadataFromJSON(md string) Option {
 // 	md["token"] = "foobar"
 // 	md["request-id"] = "123"
 // 	WithMetadata(&md)
-func WithMetadata(md map[string]string) Option {
+func WithMetadata(md []map[string]string) Option {
 	return func(o *RunConfig) error {
 		mdJSON, err := json.Marshal(md)
 		if err != nil {

--- a/runner/options_test.go
+++ b/runner/options_test.go
@@ -109,6 +109,50 @@ func TestRunConfig_newRunConfig(t *testing.T) {
 		assert.Equal(t, c.enableCompression, false)
 	})
 
+	t.Run("with JSON array as a metadata value", func(t *testing.T) {
+		c, err := NewConfig(
+			"call", "localhost:50050",
+			WithInsecure(true),
+			WithTotalRequests(100),
+			WithConcurrency(20),
+			WithQPS(5),
+			WithSkipFirst(5),
+			WithRunDuration(time.Duration(5*time.Minute)),
+			WithKeepalive(time.Duration(60*time.Second)),
+			WithTimeout(time.Duration(10*time.Second)),
+			WithDialTimeout(time.Duration(30*time.Second)),
+			WithName("asdf"),
+			WithCPUs(4),
+			WithDataFromJSON(`{"name":"bob"}`),
+			WithMetadataFromJSON(`[{"request-id":"123"}, {"request-id":"456"}]`),
+			WithProtoFile("testdata/data.proto", []string{"/home/protos"}),
+		)
+
+		assert.NoError(t, err)
+
+		assert.Equal(t, "call", c.call)
+		assert.Equal(t, "localhost:50050", c.host)
+		assert.Equal(t, true, c.insecure)
+		assert.Equal(t, math.MaxInt32, c.n)
+		assert.Equal(t, 20, c.c)
+		assert.Equal(t, 5, c.qps)
+		assert.Equal(t, 5, c.skipFirst)
+		assert.Equal(t, false, c.binary)
+		assert.Equal(t, time.Duration(5*time.Minute), c.z)
+		assert.Equal(t, time.Duration(60*time.Second), c.keepaliveTime)
+		assert.Equal(t, time.Duration(10*time.Second), c.timeout)
+		assert.Equal(t, time.Duration(30*time.Second), c.dialTimeout)
+		assert.Equal(t, 4, c.cpus)
+		assert.False(t, c.binary)
+		assert.Equal(t, "asdf", c.name)
+		assert.Equal(t, `{"name":"bob"}`, string(c.data))
+		assert.Equal(t, `[{"request-id":"123"}, {"request-id":"456"}]`, string(c.metadata))
+		assert.Equal(t, "testdata/data.proto", string(c.proto))
+		assert.Equal(t, "", string(c.protoset))
+		assert.Equal(t, []string{"testdata", ".", "/home/protos"}, c.importPaths)
+		assert.Equal(t, c.enableCompression, false)
+	})
+
 	t.Run("with binary data, protoset and metadata file", func(t *testing.T) {
 		c, err := NewConfig(
 			"call", "localhost:50050",
@@ -169,9 +213,13 @@ func TestRunConfig_newRunConfig(t *testing.T) {
 			Age:    11,
 			Fruits: []string{"apple", "peach", "pear"}}
 
+		var mdArray []map[string]string
+
 		md := make(map[string]string)
 		md["token"] = "foobar"
 		md["request-id"] = "123"
+
+		mdArray = append(mdArray, md)
 
 		tags := make(map[string]string)
 		tags["env"] = "staging"
@@ -195,7 +243,7 @@ func TestRunConfig_newRunConfig(t *testing.T) {
 			WithName("asdf"),
 			WithCPUs(4),
 			WithData(d),
-			WithMetadata(md),
+			WithMetadata(mdArray),
 			WithTags(tags),
 			WithReflectionMetadata(rmd),
 		)


### PR DESCRIPTION
This pull request updates the code so in addition to specifying a single metadata object which is used for all the outgoing gRPC calls / requests, user can also specify a list of metadata objects to use for the outgoing requests.

This allows people to use different metadata for different requests. It's similar to the change implemented in #87, but this one is for the actual request metadata and for the payload / body / data.

## Background, Context, Rationale

#87 implemented support which allows users to specify different messages for unary calls. Those messages are then used in a round robin fashion for the outgoing requests (thanks to @ezsilmar for implementing that).

That functionality comes handy in many scenarios where sending the same data with every request will not results in a representative result (e.g. due to the server logic, caching or similar).

In our case, actual processing performed by the server also depends on the metadata field values.

This means if we want to get a representative result when performing simple gRPC server level benchmark using this tool, we need to send different (and specific) metadata for each outgoing request.

## Proposed Implementation

This PR implements a change which allows user to either specify an object directly or an array of objects for the ``metadata`` argument.

If an array is specified, we will use different metadata values for different outgoing requests in a round-robin fashion.

This follows similar approach which is already used for the actual messages and was implemented in #86.

Proposed implementation in this PR is just a quick hacky WIP version of this change.

If other people agree this is indeed a good feature / functionality to have, I will clean it up and finish it.

## Open Questions

Making sure the change is fully backward compatible (aka that both approaches - single object and an array with objects is supported) is pretty straight forward when metadata is either specified directly as a command line argument or read from a file.

This becomes more problematic though when reading configuration from a JSON or TOML configuration file.

One approach I could think of is to "rewrite" config on load and ensure ``metadata`` field value is always an array. This approach is somewhat fragile not ideal so I wonder if there is a better way to handle that (suggestions and feedback is welcome).

## TODO

- [ ] Finish the implementation
  - [ ] Make sure the change is fully backward compatible (ensure we support both notations - single object or an array for objects for metadata specified either via command line or config file)
  - [ ] Clean up the code
  - [ ] Tests
  - [ ] Update docs
  - [ ] Update examples
  - [ ] Update readme