### PR TITLE
[feature] add client side load balancing

### DIFF
--- a/runner/options.go
+++ b/runner/options.go
@@ -66,6 +66,8 @@ type RunConfig struct {
 	// data
 	data []byte
 
+	// lbStrategy
+	lbStrategy string
 	// data func
 	dataFunc BinaryDataFunc
 
@@ -305,6 +307,16 @@ func WithBinaryData(data []byte) Option {
 	return func(o *RunConfig) error {
 		o.data = data
 		o.binary = true
+
+		return nil
+	}
+}
+
+// WithClientLoadBalancing specifies the LB strategy to use
+// The strategies has to be self written and pre defined
+func WithClientLoadBalancing(strategy string) Option {
+	return func(o *RunConfig) error {
+		o.lbStrategy = strategy
 
 		return nil
 	}

--- a/runner/options_test.go
+++ b/runner/options_test.go
@@ -125,8 +125,9 @@ func TestRunConfig_newRunConfig(t *testing.T) {
 			WithDialTimeout(time.Duration(30*time.Second)),
 			WithName("asdf"),
 			WithCPUs(4),
-			WithBinaryDataFunc(changeFunc),
 			WithBinaryData([]byte("asdf1234foobar")),
+			WithBinaryDataFunc(changeFunc),
+			WithClientLoadBalancing(`{"loadBalancingPolicy":"round_robin"}`),
 			WithMetadataFromFile("../testdata/metadata.json"),
 			WithProtoset("testdata/bundle.protoset"),
 		)
@@ -152,6 +153,7 @@ func TestRunConfig_newRunConfig(t *testing.T) {
 		assert.Equal(t, 4, c.cpus)
 		assert.Equal(t, "asdf", c.name)
 		assert.Equal(t, []byte("asdf1234foobar"), c.data)
+		assert.Equal(t, `{"loadBalancingPolicy":"round_robin"}`, c.lbStrategy)
 		funcName1 := runtime.FuncForPC(reflect.ValueOf(changeFunc).Pointer()).Name()
 		funcName2 := runtime.FuncForPC(reflect.ValueOf(c.dataFunc).Pointer()).Name()
 		assert.Equal(t, funcName1, funcName2)

--- a/runner/requester.go
+++ b/runner/requester.go
@@ -322,6 +322,10 @@ func (b *Requester) newClientConn(withStatsHandler bool) (*grpc.ClientConn, erro
 			grpc.MaxCallSendMsgSize(math.MaxInt32),
 		))
 
+	if b.config.lbStrategy != "" {
+		opts = append(opts, grpc.WithBalancerName(b.config.lbStrategy))
+	}
+
 	// create client connection
 	return grpc.DialContext(ctx, b.config.host, opts...)
 }


### PR DESCRIPTION
Adds the option to define a client side load balancer.
There are only 2 available balancers by default: pick_first and round_robin. Default is pick_first.

This option can be defined on the client and passed as an option e.g.
```go
. WithClientLoadBalancing("round_robin") // for default round robin instead of first value
```


fixes: https://github.com/bojand/ghz/issues/103


## Note
This PR uses an old grpc deprecated [option](https://github.com/grpc/grpc-go/issues/3003) because some clients are not up to date to use the newest experimental api and therefore don't even have that option.

Linting fails because of ^
```
Error: runner/requester.go:326:23: SA1019: grpc.WithBalancerName is deprecated: use WithDefaultServiceConfig and WithDisableServiceConfig instead.  Will be removed in a future 1.x release.  (staticcheck)
		opts = append(opts, grpc.WithBalancerName(b.config.lbStrategy))
		                    ^
Error: Process completed with exit code 1.
```