### PR TITLE
base64 decode binary metadata

### DIFF
--- a/runner/calldata.go
+++ b/runner/calldata.go
@@ -2,8 +2,10 @@ package runner
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"math/rand"
+	"strings"
 	"text/template"
 	"text/template/parse"
 	"time"
@@ -180,6 +182,16 @@ func (td *CallData) executeMetadata(metadata string) (map[string]string, error) 
 		err = json.Unmarshal(input, &mdMap)
 		if err != nil {
 			return nil, err
+		}
+
+		for key, value := range mdMap {
+			if strings.HasSuffix(key, "-bin") {
+				decoded, err := base64.StdEncoding.DecodeString(value)
+				if err != nil {
+					return nil, err
+				}
+				mdMap[key] = string(decoded)
+			}
 		}
 	}
 

--- a/runner/calldata_test.go
+++ b/runner/calldata_test.go
@@ -114,6 +114,11 @@ func TestCallData_ExecuteMetadata(t *testing.T) {
 			map[string]string{"trace_id": "asdf {{.Something}} {{.MethodName}} bob"},
 			false,
 		},
+		{"with binary data",
+			`{"data-bin":"YmFzZTY0"}`,
+			map[string]string{"data-bin": "base64"},
+			false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
According to https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md#storing-binary-data-in-metadata -bin metadata is base64 encoded in gRPC, but it's not possible to represent binary values in json. This assumes that any -bin metadata header should be decoded as base64 before passed along to gRPC.