### PR TITLE
Add support for passing Protoset Binary as runner option

### DIFF
--- a/protodesc/protodesc.go
+++ b/protodesc/protodesc.go
@@ -41,17 +41,27 @@ func GetMethodDescFromProto(call, proto string, imports []string) (*desc.MethodD
 	return getMethodDesc(call, files)
 }
 
-// GetMethodDescFromProtoSet gets method descritor for the given call symbol from protoset file given my path protoset
+// GetMethodDescFromProtoSet gets method descriptor for the given call symbol from protoset file given my path protoset
 func GetMethodDescFromProtoSet(call, protoset string) (*desc.MethodDescriptor, error) {
 	b, err := ioutil.ReadFile(protoset)
 	if err != nil {
 		return nil, fmt.Errorf("could not load protoset file %q: %v", protoset, err)
 	}
 
-	var fds descriptor.FileDescriptorSet
-	err = proto.Unmarshal(b, &fds)
-	if err != nil {
+	res, err := GetMethodDescFromProtoSetBinary(call, b)
+	if err != nil && strings.Contains(err.Error(), "could not parse contents of protoset binary") {
 		return nil, fmt.Errorf("could not parse contents of protoset file %q: %v", protoset, err)
+	}
+
+	return res, err
+}
+
+// GetMethodDescFromProtoSetBinary gets method descriptor for the given call symbol from protoset binary
+func GetMethodDescFromProtoSetBinary(call string, b []byte) (*desc.MethodDescriptor, error) {
+	var fds descriptor.FileDescriptorSet
+	err := proto.Unmarshal(b, &fds)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse contents of protoset binary: %v", err)
 	}
 
 	unresolved := map[string]*descriptor.FileDescriptorProto{}

--- a/runner/options.go
+++ b/runner/options.go
@@ -43,6 +43,7 @@ type RunConfig struct {
 	proto             string
 	importPaths       []string
 	protoset          string
+	protosetBinary    []byte
 	enableCompression bool
 
 	// security settings

--- a/runner/options.go
+++ b/runner/options.go
@@ -717,6 +717,14 @@ func WithProtoset(protoset string) Option {
 	}
 }
 
+func WithProtosetBinary(b []byte) Option {
+	return func(o *RunConfig) error {
+		o.protosetBinary = b
+
+		return nil
+	}
+}
+
 // WithStreamInterval sets the stream interval
 func WithStreamInterval(d time.Duration) Option {
 	return func(o *RunConfig) error {

--- a/runner/requester.go
+++ b/runner/requester.go
@@ -78,6 +78,8 @@ func NewRequester(c *RunConfig) (*Requester, error) {
 		mtd, err = protodesc.GetMethodDescFromProto(c.call, c.proto, c.importPaths)
 	} else if c.protoset != "" {
 		mtd, err = protodesc.GetMethodDescFromProtoSet(c.call, c.protoset)
+	} else if c.protosetBinary != nil {
+		mtd, err = protodesc.GetMethodDescFromProtoSetBinary(c.call, c.protosetBinary)
 	} else {
 		// use reflection to get method descriptor
 		var cc *grpc.ClientConn


### PR DESCRIPTION
In environments where the ghz application has no access to the file system, users might need to embed the protoset binary into the source code and pass it to the runner directly. This PR adds this functionality.