### PR TITLE
Fix typo in command

### DIFF
--- a/www/docs/extras.md
+++ b/www/docs/extras.md
@@ -28,5 +28,5 @@ For convenience we include prebuilt [Grafana](http://grafana.com/) dashboards fo
 `ghz` can be used with [Prototool](https://github.com/uber/prototool) using the [`descriptor-set`](https://github.com/uber/prototool/tree/dev/docs#prototool-descriptor-set) command:
 
 ```
-ghz -protoset $(prototool descriptor-set --include-imports --tmp) ...
+ghz --protoset $(prototool descriptor-set --include-imports --tmp) ...
 ```


### PR DESCRIPTION
Running the command from here gave me this error:

`ghz: error: unknown short flag '-p', try --help`

This should fix it, was just missing a hyphen.