### PR TITLE
Add option to pass response to end user

### DIFF
--- a/runner/config.go
+++ b/runner/config.go
@@ -116,7 +116,6 @@ type Config struct {
 	LBStrategy            string            `json:"lb-strategy" toml:"lb-strategy" yaml:"lb-strategy"`
 	MaxCallRecvMsgSize    string            `json:"max-recv-message-size" toml:"max-recv-message-size" yaml:"max-recv-message-size"`
 	MaxCallSendMsgSize string `json:"max-send-message-size" toml:"max-send-message-size" yaml:"max-send-message-size"`
-	StoreResponsesAt   string `json:"store-responses-at" toml:"store-responses-at" yaml:"store-responses-at"`
 }
 
 func checkData(data interface{}) error {

--- a/runner/config.go
+++ b/runner/config.go
@@ -115,7 +115,8 @@ type Config struct {
 	LoadMaxDuration       Duration          `json:"load-max-duration" toml:"load-max-duration" yaml:"load-max-duration"`
 	LBStrategy            string            `json:"lb-strategy" toml:"lb-strategy" yaml:"lb-strategy"`
 	MaxCallRecvMsgSize    string            `json:"max-recv-message-size" toml:"max-recv-message-size" yaml:"max-recv-message-size"`
-	MaxCallSendMsgSize    string            `json:"max-send-message-size" toml:"max-send-message-size" yaml:"max-send-message-size"`
+	MaxCallSendMsgSize string `json:"max-send-message-size" toml:"max-send-message-size" yaml:"max-send-message-size"`
+	StoreResponsesAt   string `json:"store-responses-at" toml:"store-responses-at" yaml:"store-responses-at"`
 }
 
 func checkData(data interface{}) error {

--- a/runner/config.go
+++ b/runner/config.go
@@ -115,7 +115,7 @@ type Config struct {
 	LoadMaxDuration       Duration          `json:"load-max-duration" toml:"load-max-duration" yaml:"load-max-duration"`
 	LBStrategy            string            `json:"lb-strategy" toml:"lb-strategy" yaml:"lb-strategy"`
 	MaxCallRecvMsgSize    string            `json:"max-recv-message-size" toml:"max-recv-message-size" yaml:"max-recv-message-size"`
-	MaxCallSendMsgSize string `json:"max-send-message-size" toml:"max-send-message-size" yaml:"max-send-message-size"`
+	MaxCallSendMsgSize    string            `json:"max-send-message-size" toml:"max-send-message-size" yaml:"max-send-message-size"`
 }
 
 func checkData(data interface{}) error {

--- a/runner/options.go
+++ b/runner/options.go
@@ -134,7 +134,7 @@ type RunConfig struct {
 	countErrors      bool
 	recvMsgFunc      StreamRecvMsgInterceptFunc
 	responsesChannel *chan proto.Message
-	stopChan *chan bool
+	stopChan         *chan bool
 }
 
 // Option controls some aspect of run
@@ -154,7 +154,7 @@ func NewConfig(call, host string, options ...Option) (*RunConfig, error) {
 		zstop:            "close",
 		loadSchedule:     ScheduleConst,
 		responsesChannel: nil,
-		stopChan: nil,
+		stopChan:         nil,
 	}
 
 	// apply options

--- a/runner/options.go
+++ b/runner/options.go
@@ -131,7 +131,8 @@ type RunConfig struct {
 	tags        []byte
 	skipFirst   int
 	countErrors bool
-	recvMsgFunc StreamRecvMsgInterceptFunc
+	recvMsgFunc      StreamRecvMsgInterceptFunc
+	storeResponsesAt string
 }
 
 // Option controls some aspect of run
@@ -142,14 +143,15 @@ func NewConfig(call, host string, options ...Option) (*RunConfig, error) {
 
 	// init with defaults
 	c := &RunConfig{
-		n:            200,
-		c:            50,
-		nConns:       1,
-		timeout:      time.Duration(20 * time.Second),
-		dialTimeout:  time.Duration(10 * time.Second),
-		cpus:         runtime.GOMAXPROCS(-1),
-		zstop:        "close",
-		loadSchedule: ScheduleConst,
+		n:                200,
+		c:                50,
+		nConns:           1,
+		timeout:          time.Duration(20 * time.Second),
+		dialTimeout:      time.Duration(10 * time.Second),
+		cpus:             runtime.GOMAXPROCS(-1),
+		zstop:            "close",
+		loadSchedule:     ScheduleConst,
+		storeResponsesAt: "",
 	}
 
 	// apply options
@@ -379,6 +381,13 @@ func WithSkipTLSVerify(skip bool) Option {
 	return func(o *RunConfig) error {
 		o.skipVerify = skip
 
+		return nil
+	}
+}
+
+func WithStoreResponsesAt(store string) Option {
+	return func(o *RunConfig) error {
+		o.storeResponsesAt = store
 		return nil
 	}
 }
@@ -1149,6 +1158,7 @@ func fromConfig(cfg *Config) []Option {
 		WithConcurrencyStepDuration(time.Duration(cfg.CStepDuration)),
 		WithConcurrencyDuration(time.Duration(cfg.CMaxDuration)),
 		WithCountErrors(cfg.CountErrors),
+		WithStoreResponsesAt(cfg.StoreResponsesAt),
 		func(o *RunConfig) error {
 			o.call = cfg.Call
 			return nil

--- a/runner/requester.go
+++ b/runner/requester.go
@@ -59,7 +59,6 @@ type Requester struct {
 	lock       sync.Mutex
 	stopReason StopReason
 	workers    []*Worker
-
 }
 
 // NewRequester creates a new requestor from the passed RunConfig

--- a/runner/requester.go
+++ b/runner/requester.go
@@ -2,17 +2,14 @@ package runner
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"math"
-	"os"
 	"strconv"
 	"sync"
 	"time"
 
 	"github.com/bojand/ghz/load"
 	"github.com/bojand/ghz/protodesc"
-	"github.com/gogo/protobuf/proto"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/dynamic"
 	"github.com/jhump/protoreflect/dynamic/grpcdynamic"
@@ -63,8 +60,6 @@ type Requester struct {
 	stopReason StopReason
 	workers    []*Worker
 
-	responseChannel chan proto.Message
-	stopChannel     chan bool
 }
 
 // NewRequester creates a new requestor from the passed RunConfig
@@ -184,61 +179,6 @@ func (b *Requester) Run() (*Report, error) {
 	go func() {
 		b.reporter.Run()
 	}()
-	
-	if b.config.storeResponsesAt != "" {
-		b.responseChannel = make(chan proto.Message)
-		go func(b *Requester) {
-			responses := make([]proto.Message, 0)
-			outputFile, err := os.Create(b.config.storeResponsesAt)
-			if err != nil {
-				b.config.log.Error("Failed to create file for storing responses. %s", err)
-				return
-			}
-
-
-			defer outputFile.Close()
-			stop := false
-			for !stop {
-				select {
-					case response := <- b.responseChannel:
-						responses = append(responses, response)
-
-						if len(responses) >= 100 {
-							for _, response := range responses {
-								data, err := json.Marshal(response)
-								if err != nil {
-									b.config.log.Error("Failed to marshal response %s", err)
-								}
-								data = append(data, '\n')
-								if _, err := outputFile.Write(data); err != nil {
-									b.config.log.Error("Failed to write response to file %s", err)
-								}
-							}
-							if outputFile.Sync() != nil {
-								b.config.log.Error("Failed to sync file %s", err)
-							}
-							responses = make([]proto.Message, 0)
-						}
-					case  <- b.stopChannel:
-						stop = true
-				}
-			}
-			for _, response := range responses {
-				data, err := json.Marshal(response)
-				if err != nil {
-					b.config.log.Error("Failed to marshal response %s", err)
-				}
-				data = append(data, '\n')
-				if _, err := outputFile.Write(data); err != nil {
-					b.config.log.Error("Failed to write response to file %s", err)
-				}
-			}
-			if outputFile.Sync() != nil {
-				b.config.log.Error("Failed to sync file %s", err)
-			}
-		}(b)
-	}
-	
 
 	wt := createWorkerTicker(b.config)
 
@@ -257,7 +197,9 @@ func (b *Requester) Run() (*Report, error) {
 func (b *Requester) Stop(reason StopReason) {
 
 	b.stopCh <- true
-	b.stopChannel <- true
+	if *b.config.stopChan != nil {
+		*b.config.stopChan <- true
+	}
 
 	b.lock.Lock()
 	b.stopReason = reason
@@ -280,7 +222,9 @@ func (b *Requester) Stop(reason StopReason) {
 // Finish finishes the test run
 func (b *Requester) Finish() *Report {
 	close(b.results)
-	b.stopChannel <- true
+	if *b.config.stopChan != nil {
+		*b.config.stopChan <- true
+	}
 	total := time.Since(b.start)
 
 	if b.config.hasLog {
@@ -463,7 +407,6 @@ func (b *Requester) runWorkers(wt load.WorkerTicker, p load.Pacer) error {
 						metadataProvider: b.metadataProvider,
 						streamRecv:       b.config.recvMsgFunc,
 						msgProvider:      b.config.dataStreamFunc,
-						responseChannel:  &b.responseChannel,
 					}
 
 					wc++ // increment worker id

--- a/runner/worker.go
+++ b/runner/worker.go
@@ -40,6 +40,7 @@ type Worker struct {
 	msgProvider      StreamMessageProviderFunc
 
 	streamRecv StreamRecvMsgInterceptFunc
+	responseChannel *chan proto.Message
 }
 
 func (w *Worker) runWorker() error {
@@ -183,6 +184,10 @@ func (w *Worker) makeUnaryRequest(ctx *context.Context, reqMD *metadata.MD, inpu
 			"response", res, "error", resErr)
 	}
 
+	if w.config.storeResponsesAt != "" {
+		*w.responseChannel <- res
+	}
+
 	return resErr
 }
 
@@ -211,6 +216,10 @@ func (w *Worker) makeClientStreamingRequest(ctx *context.Context,
 			w.config.log.Debugw("Close and receive", "workerID", w.workerID, "call type", "client-streaming",
 				"call", w.mtd.GetFullyQualifiedName(),
 				"response", res, "error", closeErr)
+		}
+
+		if w.config.storeResponsesAt != "" {
+			*w.responseChannel <- res
 		}
 	}
 
@@ -369,6 +378,10 @@ func (w *Worker) makeServerStreamingRequest(ctx *context.Context, input *dynamic
 				"response", res, "error", err)
 		}
 
+		if w.config.storeResponsesAt != "" {
+			*w.responseChannel <- res
+		}
+
 		// with any of the cancellation operations we can't just bail
 		// we have to drain the messages until the server gets the cancel and ends their side of the stream
 
@@ -475,6 +488,10 @@ func (w *Worker) makeBidiRequest(ctx *context.Context,
 				w.config.log.Debugw("Receive message", "workerID", w.workerID, "call type", "bidi",
 					"call", w.mtd.GetFullyQualifiedName(),
 					"response", res, "error", recvErr)
+			}
+
+			if w.config.storeResponsesAt != "" {
+				*w.responseChannel <- res
 			}
 
 			if w.streamRecv != nil {

--- a/runner/worker.go
+++ b/runner/worker.go
@@ -40,7 +40,6 @@ type Worker struct {
 	msgProvider      StreamMessageProviderFunc
 
 	streamRecv StreamRecvMsgInterceptFunc
-	responseChannel *chan proto.Message
 }
 
 func (w *Worker) runWorker() error {
@@ -184,8 +183,8 @@ func (w *Worker) makeUnaryRequest(ctx *context.Context, reqMD *metadata.MD, inpu
 			"response", res, "error", resErr)
 	}
 
-	if w.config.storeResponsesAt != "" {
-		*w.responseChannel <- res
+	if w.config.responsesChannel != nil {
+		*w.config.responsesChannel <- res
 	}
 
 	return resErr
@@ -218,8 +217,8 @@ func (w *Worker) makeClientStreamingRequest(ctx *context.Context,
 				"response", res, "error", closeErr)
 		}
 
-		if w.config.storeResponsesAt != "" {
-			*w.responseChannel <- res
+		if w.config.responsesChannel != nil {
+			*w.config.responsesChannel <- res
 		}
 	}
 
@@ -378,8 +377,8 @@ func (w *Worker) makeServerStreamingRequest(ctx *context.Context, input *dynamic
 				"response", res, "error", err)
 		}
 
-		if w.config.storeResponsesAt != "" {
-			*w.responseChannel <- res
+		if w.config.responsesChannel != nil {
+			*w.config.responsesChannel <- res
 		}
 
 		// with any of the cancellation operations we can't just bail
@@ -490,8 +489,8 @@ func (w *Worker) makeBidiRequest(ctx *context.Context,
 					"response", res, "error", recvErr)
 			}
 
-			if w.config.storeResponsesAt != "" {
-				*w.responseChannel <- res
+			if w.config.responsesChannel != nil {
+				*w.config.responsesChannel <- res
 			}
 
 			if w.streamRecv != nil {


### PR DESCRIPTION
We have a use case to check what is in the response. However, ghz does not support this functionality atm (correct me if I am wrong). Hope we can add this. Thanks!