### PR TITLE
fix lb strategy logging error

### DIFF
--- a/cmd/ghz/main.go
+++ b/cmd/ghz/main.go
@@ -315,8 +315,8 @@ func main() {
 		options = append(options, runner.WithLogger(logger))
 	}
 
-	if isLBStrategySet && cfg.Host != "" && !strings.HasPrefix(cfg.Host, "dns:///") {
-		logger.Warn("Load balancing strategy set without using DNS (dns:///) scheme. ", "Strategy: ", cfg.LBStrategy, " Host: ", cfg.Host)
+	if logger != nil && isLBStrategySet && cfg.Host != "" && !strings.HasPrefix(cfg.Host, "dns:///") {
+		logger.Warnw("Load balancing strategy set without using DNS (dns:///) scheme. ", "strategy", cfg.LBStrategy, "host", cfg.Host)
 	}
 
 	if logger != nil {

--- a/cmd/ghz/main.go
+++ b/cmd/ghz/main.go
@@ -316,7 +316,7 @@ func main() {
 	}
 
 	if logger != nil && isLBStrategySet && cfg.Host != "" && !strings.HasPrefix(cfg.Host, "dns:///") {
-		logger.Warnw("Load balancing strategy set without using DNS (dns:///) scheme. ", "strategy", cfg.LBStrategy, "host", cfg.Host)
+		logger.Warnw("Load balancing strategy set without using DNS (dns:///) scheme", "strategy", cfg.LBStrategy, "host", cfg.Host)
 	}
 
 	if logger != nil {


### PR DESCRIPTION
To address issue https://github.com/bojand/ghz/issues/313 

Issue was supposed to be resolved here: https://github.com/bojand/ghz/commit/76c59b6e2abc06fa3c7f4b2bf7b44b9272ceb651

... But I was still getting the same error when building the latest master and running locally - e.g.

```
➜  dist git:(master) ✗ ./ghz --insecure \
--proto=usage_data_gateway.proto \
--call=UsageDataGateway.Ping \
--lb-strategy=round_robin \
localhost:6421

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x134edf2]

goroutine 1 [running]:
go.uber.org/zap.(*SugaredLogger).log(0x0, 0x1, {0x0, 0x0}, {0xc00053d9d0, 0x8, 0x5}, {0x0, 0x0, 0x0})
	/Users/markusnotti/go/pkg/mod/go.uber.org/zap@v1.13.0/sugar.go:221 +0x52
go.uber.org/zap.(*SugaredLogger).Warn(...)
	/Users/markusnotti/go/pkg/mod/go.uber.org/zap@v1.13.0/sugar.go:107
main.main()
	/Users/markusnotti/code_personal/ghz/cmd/ghz/main.go:319 +0x53c
```

Have tested locally (macOS) with make build and run the same command as above successfully. 

Also tested with `--debug=debug.json` option and confirmed the log line appears and looks as it should i.e.
`{"level":"warn","time":"2022-03-16T14:55:33.914884-07:00","message":"Load balancing strategy set without using DNS (dns:///) scheme. ","strategy":"round_robin","host":"localhost:6421"}`

