### PR TITLE
fix deprecated usage of grpc.WithBalancerName in runner/requester.go

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,5 +36,3 @@ issues:
     - path: protodesc/
       text: "SA1019: package github.com/golang/protobuf"
 
-    - path: runner/requester.go
-      text: "SA1019: grpc.WithBalancerName"

--- a/runner/requester.go
+++ b/runner/requester.go
@@ -343,7 +343,8 @@ func (b *Requester) newClientConn(withStatsHandler bool) (*grpc.ClientConn, erro
 	}
 
 	if b.config.lbStrategy != "" {
-		opts = append(opts, grpc.WithBalancerName(b.config.lbStrategy))
+		grpcServiceConfig := fmt.Sprintf(`{"loadBalancingPolicy":"%s"}`, b.config.lbStrategy)
+		opts = append(opts, grpc.WithDefaultServiceConfig(grpcServiceConfig))
 	}
 
 	// create client connection


### PR DESCRIPTION
Closes #356