### PR TITLE
chore: guide go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ cd cmd/ghz
 go build .
 ```
 
+**Install using go >= 1.16**
+
+```sh
+go install github.com/bojand/ghz/cmd/ghz@latest
+```
+
 ## Usage
 
 ```


### PR DESCRIPTION
Since go 1.16, go install command is introduced

https://go.dev/ref/mod#go-install