### PR TITLE
added prometheus metrics to the live running host

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/golangci/golangci-lint v1.46.2
 	github.com/google/uuid v1.3.0
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/jhump/protoreflect v1.9.0
 	github.com/jinzhu/configor v1.1.1
 	github.com/jinzhu/gorm v1.9.11
@@ -20,6 +21,7 @@ require (
 	github.com/labstack/gommon v0.3.0
 	github.com/mfridman/tparse v0.10.3
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.32.1
 	github.com/rakyll/statik v0.1.6
@@ -157,7 +159,6 @@ require (
 	github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/polyfloyd/go-errorlint v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/quasilyte/go-ruleguard v0.3.16-0.20220213074421-6aa060fab41a // indirect
 	github.com/quasilyte/gogrep v0.0.0-20220120141003-628d8b3623b5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -432,6 +432,7 @@ github.com/gostaticanalysis/testutil v0.4.0 h1:nhdCmubdmDF6VEatUNjgUZBJKWRqugoIS
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.2/go.mod h1:EaizFBKfUKtMIF5iaDEhniwNedqGo9FuLFzppDr3uwI=
+github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.12.1/go.mod h1:8XEsbTttt/W+VvjtQhLACqCisSPWTxCZ7sBRjU6iH9c=

--- a/runner/config.go
+++ b/runner/config.go
@@ -97,6 +97,7 @@ type Config struct {
 	StreamDynamicMessages bool              `json:"stream-dynamic-messages" toml:"stream-dynamic-messages" yaml:"stream-dynamic-messages"`
 	Output                string            `json:"output" toml:"output" yaml:"output"`
 	Format                string            `json:"format" toml:"format" yaml:"format" default:"summary"`
+	Prometheus            bool              `json:"prometheus" toml:"prometheus" yaml:"prometheus"`
 	DialTimeout           Duration          `json:"connect-timeout" toml:"connect-timeout" yaml:"connect-timeout" default:"10s"`
 	KeepaliveTime         Duration          `json:"keepalive" toml:"keepalive" yaml:"keepalive"`
 	CPUs                  uint              `json:"cpus" toml:"cpus" yaml:"cpus"`

--- a/runner/options.go
+++ b/runner/options.go
@@ -48,6 +48,7 @@ type RunConfig struct {
 	protosetBinary     []byte
 	enableCompression  bool
 	defaultCallOptions []grpc.CallOption
+	prometheusEnabled  bool
 
 	// security settings
 	creds      credentials.TransportCredentials
@@ -370,6 +371,17 @@ func WithRootCertificate(cert string) Option {
 	}
 }
 
+// WithPrometheusEnabled specifies that this run should be done using insecure mode
+//
+//	WithPrometheusEnabled(true)
+func WithPrometheusEnabled(prometheus bool) Option {
+	return func(o *RunConfig) error {
+		o.prometheusEnabled = prometheus
+
+		return nil
+	}
+}
+
 // WithInsecure specifies that this run should be done using insecure mode
 //
 //	WithInsecure(true)
@@ -441,7 +453,6 @@ func WithRunDuration(z time.Duration) Option {
 func WithDurationStopAction(action string) Option {
 	return func(o *RunConfig) error {
 		action = strings.ToLower(action)
-
 		if action == "close" || action == "wait" || action == "ignore" {
 			o.zstop = action
 		}
@@ -1211,6 +1222,7 @@ func fromConfig(cfg *Config) []Option {
 		WithCountErrors(cfg.CountErrors),
 		WithDisableTemplateFuncs(cfg.DisableTemplateFuncs),
 		WithDisableTemplateData(cfg.DisableTemplateData),
+		WithPrometheusEnabled(cfg.Prometheus),
 		func(o *RunConfig) error {
 			o.call = cfg.Call
 			return nil


### PR DESCRIPTION
Hello, i found your project and was looking to use it for some very long runs and would prefer the metric data to be sent live if possible. AFAIK you cant do this out of the box. I've tested a quick-n-dirty implementation of [go-grpc-prometheus ](https://github.com/grpc-ecosystem/go-grpc-prometheus) with config flags to turn it on/off. 

Here is a sample dashboard  all based on the examples [here](https://github.com/grpc-ecosystem/go-grpc-prometheus#useful-query-examples).
<img width="1838" alt="Screen Shot 2023-01-13 at 3 32 38 PM" src="https://user-images.githubusercontent.com/16598119/212423708-0864f4ef-d1ea-4b27-9a5c-8ea9b2df69c9.png">


Thanks, let me know what you think. 

