### PR TITLE
feat: redo input/response encoding for easy parsing

### DIFF
--- a/runner/worker.go
+++ b/runner/worker.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -177,10 +178,13 @@ func (w *Worker) makeUnaryRequest(ctx *context.Context, reqMD *metadata.MD, inpu
 	res, resErr = w.stub.InvokeRpc(*ctx, w.mtd, input, callOptions...)
 
 	if w.config.hasLog {
+		inputData, _ := input.MarshalJSON()
+		resData, _ := json.Marshal(res)
+
 		w.config.log.Debugw("Received response", "workerID", w.workerID, "call type", "unary",
 			"call", w.mtd.GetFullyQualifiedName(),
-			"input", input, "metadata", reqMD,
-			"response", res, "error", resErr)
+			"input", string(inputData), "metadata", reqMD,
+			"response", string(resData), "error", resErr)
 	}
 
 	return resErr


### PR DESCRIPTION
cc https://github.com/bojand/ghz/issues/247
cc https://github.com/bojand/ghz/pull/322

EDIT: 
This enables us to **chain** `ghz` calls and thus set up load testing scenarios.
Here's an example usage:

```bash
req_books=$(mktemp)
rep_books=$(mktemp)
req_gets=$(mktemp)
rep_gets=$(mktemp)

# Book
P "Booking $TOTAL IPs..."
source="$(printf '{"privateNetworkId":"%s"}' "$PRIVATE_NETWORK_ID")"

jq \
    --arg PROJECT_ID "$PROJECT_ID" \
    --argjson tags "$TAGS" \
    --argjson TOTAL "$TOTAL" \
    --argjson source "$source" \
    -nR '[range($TOTAL) | {projectId:$PROJECT_ID, tags:$tags, source:$source, resource:{id:input, type:"instance_server"}}]' \
    < <(for ((i=0; i<TOTAL; i++)); do uuidgen ; done) \
    >"$req_books"

DEBUG="$rep_books" RPS=10 load \
    --proto api.proto \
    --call v1.Api.BookIP \
    --data-file "$req_books"


# Get
cat "$rep_books" | jq -r .response | jq 'select(. != null) | {ip_id:.id}' | jq -s . >"$req_gets"
booked_ips=$(grep -Fc '"ip_id":' "$req_gets")
P "Getting $booked_ips IPs..."

DEBUG="$rep_gets" TOTAL="$booked_ips" load \
    --proto api.proto \
    --call v1.Api.GetIP \
    --data-file "$req_gets"
```
where `load` is a wrapper around `ghz`
```bash
load() {
    local args=()

    if [[ "$DEBUG" != '' ]]; then
        args+=(--debug "$DEBUG")
    fi

    args+=(--total "$TOTAL")
    args+=(--rps "$RPS")
    args+=(--cacert "$(dirname "$0")"/../api.pem)
    args+=(--import-paths "$PROTOBUF_DIR")
    args+=(--disable-template-functions)
    args+=(--disable-template-data)
    args+=(--output /dev/stderr)

    if ! [[ "$*" =~ .*' --metadata '.* ]]; then
        args+=(--metadata "{\"x-auth-token\":\"$TOKEN\", \"x-region\":\"$REGION\"}")
    fi

    args+=("$@")

    args+=(api.example.com:443)

    ghz "${args[@]}"

    if [[ -s "$DEBUG" ]]; then
        # Print requests and their responses to STDERR if any
        cat "$DEBUG" | jq 'select(.input | . != null) | select(.error | . != null)' | jq -S --tab '. | {error:.error, req:.input, rep:.response}' 1>&2
    fi
}
```
