### PR TITLE
Adds a stream interceptor to keep state between the send and receive calls

### DIFF
--- a/runner/data.go
+++ b/runner/data.go
@@ -44,6 +44,16 @@ type StreamMessageProviderFunc func(*CallData) (*dynamic.Message, error)
 // Clients can return ErrEndStream to end the call early
 type StreamRecvMsgInterceptFunc func(*dynamic.Message, error) error
 
+// StreamInterceptorProviderFunc is an interface for a function invoked to generate a stream interceptor
+type StreamInterceptorProviderFunc func(*CallData) StreamInterceptor
+
+// StreamInterceptor is an interface for sending and receiving stream messages.
+// The interceptor can keep shared state for the send and receive calls.
+type StreamInterceptor interface {
+	Recv(*dynamic.Message, error) error
+	Send(*CallData) (*dynamic.Message, error)
+}
+
 type dataProvider struct {
 	binary   bool
 	data     []byte

--- a/runner/options.go
+++ b/runner/options.go
@@ -129,12 +129,13 @@ type RunConfig struct {
 	disableTemplateData  bool
 
 	// misc
-	name        string
-	cpus        int
-	tags        []byte
-	skipFirst   int
-	countErrors bool
-	recvMsgFunc StreamRecvMsgInterceptFunc
+	name                          string
+	cpus                          int
+	tags                          []byte
+	skipFirst                     int
+	countErrors                   bool
+	recvMsgFunc                   StreamRecvMsgInterceptFunc
+	streamInterceptorProviderFunc StreamInterceptorProviderFunc
 }
 
 // Option controls some aspect of run
@@ -1029,6 +1030,15 @@ func WithWorkerTicker(ticker load.WorkerTicker) Option {
 func WithStreamRecvMsgIntercept(fn StreamRecvMsgInterceptFunc) Option {
 	return func(o *RunConfig) error {
 		o.recvMsgFunc = fn
+
+		return nil
+	}
+}
+
+// WithStreamInterceptor specifies the stream interceptor provider function
+func WithStreamInterceptorProviderFunc(interceptor StreamInterceptorProviderFunc) Option {
+	return func(o *RunConfig) error {
+		o.streamInterceptorProviderFunc = interceptor
 
 		return nil
 	}

--- a/runner/requester.go
+++ b/runner/requester.go
@@ -389,17 +389,18 @@ func (b *Requester) runWorkers(wt load.WorkerTicker, p load.Pacer) error {
 					}
 
 					w := Worker{
-						ticks:            ticks,
-						active:           true,
-						stub:             b.stubs[n],
-						mtd:              b.mtd,
-						config:           b.config,
-						stopCh:           make(chan bool),
-						workerID:         wID,
-						dataProvider:     b.dataProvider,
-						metadataProvider: b.metadataProvider,
-						streamRecv:       b.config.recvMsgFunc,
-						msgProvider:      b.config.dataStreamFunc,
+						ticks:                         ticks,
+						active:                        true,
+						stub:                          b.stubs[n],
+						mtd:                           b.mtd,
+						config:                        b.config,
+						stopCh:                        make(chan bool),
+						workerID:                      wID,
+						dataProvider:                  b.dataProvider,
+						metadataProvider:              b.metadataProvider,
+						streamRecv:                    b.config.recvMsgFunc,
+						msgProvider:                   b.config.dataStreamFunc,
+						streamInterceptorProviderFunc: b.config.streamInterceptorProviderFunc,
 					}
 
 					wc++ // increment worker id


### PR DESCRIPTION
Adds an new option `WithStreamInterceptorProviderFunc` where a StreamInterceptorProviderFunc can be specified. With this option a new Stream Interceptor will be created for each new stream created.  The Stream Interceptor's Send and Recv functions will be called when a message is sent or received. Unlike the `StreamRecvMsgInterceptFunc` and `StreamMessageProviderFunc`, the StreamInterceptor can keep state that both Send and Recv functions may need access to.

Here is an example of how to use the Stream Interceptor:
`

        type ABCStreamInterceptor struct {
		MsgRcvCount  int
		MsgSendCount int
                MsgChan 	 chan int
	}

	func (s *ABCStreamInterceptor) Send(callData *CallData) (*dynamic.Message, error) {
		defer func() { s.MsgSendCount++ }()
		switch s.MsgSendCount {
		case 0:
			return dynamic.AsDynamicMessage(&exampleapi.Request{
				Num: 1,
			})
		case 1:
			num := <-s.MsgChan
			return dynamic.AsDynamicMessage(&exampleapi.Request{
				Num: num,
			})
		default:
			return nil, fmt.Errorf("unknown msg send")
		}
	}

	func (s *ABCStreamInterceptor) Recv(msg *dynamic.Message, err error) error {
		if msg == nil {
			return err
		}
		s.MsgRcvCount++

		reply := exampleapi.Response{}
		err = msg.ConvertTo(reply)
		if err != nil {
			return err
		}

		switch s.MsgRcvCount {
		case 0:
			s.MsgChan <- reply.Num
			return nil
		case 1:
			return runner.ErrEndStream
		default:
			return fmt.Errorf("unknown msg recv")
		}
	}

	WithStreamInterceptorProviderFunc(func NewABCInterceptor() StreamInterceptor {
		return &ABCStreamInterceptor{
				MsgChan:          make(chan exampleapi.response, 1),
			}
		}
	})`