### PR TITLE
Added WithTransportCredentials option to be able to manually set TransportCredentials

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bojand/ghz
+module github.com/synackSA/ghz
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/synackSA/ghz
+module github.com/bojand/ghz
 
 go 1.18
 

--- a/runner/options.go
+++ b/runner/options.go
@@ -248,6 +248,10 @@ func NewConfig(call, host string, options ...Option) (*RunConfig, error) {
 		return nil, errors.New("you cannot skip more requests than those run")
 	}
 
+	if c.creds != nil {
+		return c, nil
+	}
+
 	creds, err := createClientTransportCredentials(
 		c.skipVerify,
 		c.cacert,
@@ -386,6 +390,21 @@ func WithInsecure(insec bool) Option {
 func WithSkipTLSVerify(skip bool) Option {
 	return func(o *RunConfig) error {
 		o.skipVerify = skip
+
+		return nil
+	}
+}
+
+// WithTransportCredentials specifies TransportCredentials to use
+//
+//	creds, _ := xds.NewClientCredentials(xds.ClientOptions{
+//		FallbackCreds: insecure.NewCredentials()
+//	})
+//
+//	opt := WithTransportCredentials(creds)
+func WithTransportCredentials(creds credentials.TransportCredentials) Option {
+	return func(o *RunConfig) error {
+		o.creds = creds
 
 		return nil
 	}

--- a/runner/options_test.go
+++ b/runner/options_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"encoding/json"
+	"google.golang.org/grpc/credentials/insecure"
 	"math"
 	"os"
 	"reflect"
@@ -118,6 +119,56 @@ func TestRunConfig_newRunConfig(t *testing.T) {
 		assert.Equal(t, "", string(c.protoset))
 		assert.Equal(t, []string{"testdata", ".", "/home/protos"}, c.importPaths)
 		assert.Equal(t, c.enableCompression, false)
+		assert.NotNil(t, c.creds)
+	})
+
+	t.Run("with transport credentials", func(t *testing.T) {
+
+		expectedCreds := insecure.NewCredentials()
+
+		c, err := NewConfig(
+			"call", "localhost:50050",
+			WithInsecure(true),
+			WithTotalRequests(100),
+			WithConcurrency(20),
+			WithRPS(5),
+			WithSkipFirst(5),
+			WithRunDuration(time.Duration(5*time.Minute)),
+			WithKeepalive(time.Duration(60*time.Second)),
+			WithTimeout(time.Duration(10*time.Second)),
+			WithDialTimeout(time.Duration(30*time.Second)),
+			WithName("asdf"),
+			WithCPUs(4),
+			WithDataFromJSON(`{"name":"bob"}`),
+			WithMetadataFromJSON(`{"request-id":"123"}`),
+			WithProtoFile("testdata/data.proto", []string{"/home/protos"}),
+			WithTransportCredentials(expectedCreds),
+		)
+
+		assert.NoError(t, err)
+
+		assert.Equal(t, "call", c.call)
+		assert.Equal(t, "localhost:50050", c.host)
+		assert.Equal(t, true, c.insecure)
+		assert.Equal(t, math.MaxInt32, c.n)
+		assert.Equal(t, 20, c.c)
+		assert.Equal(t, 5, c.rps)
+		assert.Equal(t, 5, c.skipFirst)
+		assert.Equal(t, false, c.binary)
+		assert.Equal(t, time.Duration(5*time.Minute), c.z)
+		assert.Equal(t, time.Duration(60*time.Second), c.keepaliveTime)
+		assert.Equal(t, time.Duration(10*time.Second), c.timeout)
+		assert.Equal(t, time.Duration(30*time.Second), c.dialTimeout)
+		assert.Equal(t, 4, c.cpus)
+		assert.False(t, c.binary)
+		assert.Equal(t, "asdf", c.name)
+		assert.Equal(t, `{"name":"bob"}`, string(c.data))
+		assert.Equal(t, `{"request-id":"123"}`, string(c.metadata))
+		assert.Equal(t, "testdata/data.proto", string(c.proto))
+		assert.Equal(t, "", string(c.protoset))
+		assert.Equal(t, []string{"testdata", ".", "/home/protos"}, c.importPaths)
+		assert.Equal(t, c.enableCompression, false)
+		assert.Equal(t, expectedCreds, c.creds)
 	})
 
 	t.Run("with binary data, protoset and metadata file", func(t *testing.T) {


### PR DESCRIPTION
We're currently trying to benchmark proxyless Istio using xDS and I needed to make an update to be able to manually set the TransportCredentials in order to follow this guide: https://istio.io/latest/blog/2021/proxyless-grpc/

This is basically building on top of the work that was already done [here in PR #300](https://github.com/bojand/ghz/pull/300)

