### PR TITLE
docs: update readme & update the go version from 1.16 to 1.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ cd cmd/ghz
 go build .
 ```
 
-**Install using go >= 1.16**
+**Install using go >= 1.18**
 
 ```sh
 go install github.com/bojand/ghz/cmd/ghz@latest


### PR DESCRIPTION
The go version in README file is not up to date. 