### PR TITLE
fix: upgrade go version -> 1.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ cd cmd/ghz
 go build .
 ```
 
-**Install using go >= 1.16**
+**Install using go >= 1.20**
 
 ```sh
 go install github.com/bojand/ghz/cmd/ghz@latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bojand/ghz
 
-go 1.18
+go 1.20
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3


### PR DESCRIPTION
the `go.mod` and `readme` files are not up to date. 
Due to upgraded `github.com/prometheus/common`, `ghz` will only compile with version 1.20 or higher. 

The compile time error(on `go1.19.13 linux/amd64`):
```
go: downloading cloud.google.com/go/compute v1.20.1
# github.com/prometheus/common/model
pkg/mod/github.com/prometheus/common@v0.53.0/model/metric.go:364:33: undefined: strings.CutPrefix
note: module requires Go 1.20
```