### PR TITLE
runner: replace deprecated jhump/protoreflect/desc in BinaryDataFunc

### DIFF
--- a/runner/data.go
+++ b/runner/data.go
@@ -217,7 +217,7 @@ func (dp *dataProvider) getMessages(ctd *CallData, i int, inputData []byte) ([]*
 	} else {
 		var err error
 		if dp.dataFunc != nil {
-			inputData = dp.dataFunc(dp.mtd, ctd)
+			inputData = dp.dataFunc(dp.mtd.UnwrapMethod(), ctd)
 		}
 		inputs, err = createPayloadsFromBin(inputData, dp.mtd)
 		if err != nil {

--- a/runner/options.go
+++ b/runner/options.go
@@ -15,10 +15,10 @@ import (
 	"time"
 
 	"github.com/bojand/ghz/load"
-	"github.com/jhump/protoreflect/desc"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	humanize "github.com/dustin/go-humanize"
 )
@@ -26,7 +26,7 @@ import (
 // BinaryDataFunc is a function that can be used for provide binary data for request programatically.
 // MethodDescriptor of the call is passed to the data function.
 // CallData for the request is passed and can be used to access worker id, request number, etc...
-type BinaryDataFunc func(mtd *desc.MethodDescriptor, callData *CallData) []byte
+type BinaryDataFunc func(mtd protoreflect.MethodDescriptor, callData *CallData) []byte
 
 // ScheduleConst is a constant load schedule
 const ScheduleConst = "const"
@@ -512,7 +512,7 @@ func WithClientLoadBalancing(strategy string) Option {
 // WithBinaryDataFunc specifies the binary data func which will be called on each request
 //
 //	WithBinaryDataFunc(changeFunc)
-func WithBinaryDataFunc(data func(mtd *desc.MethodDescriptor, callData *CallData) []byte) Option {
+func WithBinaryDataFunc(data func(mtd protoreflect.MethodDescriptor, callData *CallData) []byte) Option {
 	return func(o *RunConfig) error {
 		o.dataFunc = data
 		o.binary = true

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -13,13 +13,13 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/uuid"
-	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/dynamic"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
-func changeFunc(mtd *desc.MethodDescriptor, cd *CallData) []byte {
+func changeFunc(mtd protoreflect.MethodDescriptor, cd *CallData) []byte {
 	msg := &helloworld.HelloRequest{}
 	msg.Name = "bob"
 	binData, _ := proto.Marshal(msg)


### PR DESCRIPTION
## Problem

  `BinaryDataFunc` and `WithBinaryDataFunc` expose `*desc.MethodDescriptor`
  from `github.com/jhump/protoreflect/desc` in their public API. That package
  is deprecated upstream with the recommendation to migrate to
  `google.golang.org/protobuf/reflect/protoreflect`.

  This forces callers to import the deprecated package just to satisfy the
  function signature — even when the `mtd` parameter is unused (which is the
  common case for binary data functions).

  ## Solution

  - Change `BinaryDataFunc` to accept `protoreflect.MethodDescriptor` (the
    standard interface from Google's v2 protobuf package) instead of
    `*desc.MethodDescriptor`
  - At the internal call site in `data.go`, convert via `(*desc.MethodDescriptor).UnwrapMethod()`
    before passing to the user function

  ## Breaking change

  Any caller that currently references `*desc.MethodDescriptor` in their
  `BinaryDataFunc` will need to update the parameter type to
  `protoreflect.MethodDescriptor`. Since `google.golang.org/protobuf` is
  already a transitive dependency of ghz, no new dependency is introduced.