### PR TITLE
Implement StreamCloseDelay

### DIFF
--- a/cmd/ghz/main.go
+++ b/cmd/ghz/main.go
@@ -193,6 +193,10 @@ var (
 	scc      = kingpin.Flag("stream-call-count", "Count of messages sent, after which client will close the stream in each streaming call.").
 			Default("0").IsSetByUser(&isSCCSet).Uint()
 
+	isSCDSet = false
+	sckd     = kingpin.Flag("stream-close-delay", "Delay after the last message is sent before closing the streaming call.").
+			Default("0").IsSetByUser(&isSCDSet).Duration()
+
 	isSDMSet = false
 	sdm      = kingpin.Flag("stream-dynamic-messages", "In streaming calls, regenerate and apply call template data on every message send.").
 			Default("false").IsSetByUser(&isSDMSet).Bool()
@@ -485,6 +489,7 @@ func createConfigFromArgs(cfg *runner.Config) error {
 	cfg.SI = runner.Duration(*si)
 	cfg.StreamCallDuration = runner.Duration(*scd)
 	cfg.StreamCallCount = *scc
+	cfg.StreamCloseDelay = runner.Duration(*sckd)
 	cfg.StreamDynamicMessages = *sdm
 	cfg.Output = *output
 	cfg.Format = *format
@@ -638,6 +643,10 @@ func mergeConfig(dest *runner.Config, src *runner.Config) error {
 
 	if isSCCSet {
 		dest.StreamCallCount = src.StreamCallCount
+	}
+
+	if isSCDSet {
+		dest.StreamCloseDelay = src.StreamCloseDelay
 	}
 
 	if isSDMSet {

--- a/runner/config.go
+++ b/runner/config.go
@@ -94,6 +94,7 @@ type Config struct {
 	SI                    Duration          `json:"stream-interval" toml:"stream-interval" yaml:"stream-interval"`
 	StreamCallDuration    Duration          `json:"stream-call-duration" toml:"stream-call-duration" yaml:"stream-call-duration"`
 	StreamCallCount       uint              `json:"stream-call-count" toml:"stream-call-count" yaml:"stream-call-count"`
+	StreamCloseDelay      Duration          `json:"stream-close-delay" toml:"stream-close-delay" yaml:"stream-close-delay"`
 	StreamDynamicMessages bool              `json:"stream-dynamic-messages" toml:"stream-dynamic-messages" yaml:"stream-dynamic-messages"`
 	Output                string            `json:"output" toml:"output" yaml:"output"`
 	Format                string            `json:"format" toml:"format" yaml:"format" default:"summary"`

--- a/runner/options.go
+++ b/runner/options.go
@@ -99,6 +99,7 @@ type RunConfig struct {
 	streamInterval        time.Duration
 	streamCallDuration    time.Duration
 	streamCallCount       uint
+	streamCloseDelay      time.Duration
 	streamDynamicMessages bool
 
 	// lbStrategy
@@ -790,6 +791,15 @@ func WithStreamCallCount(c uint) Option {
 	}
 }
 
+// WithStreamCloseDelay sets the delay between sending the last message and closing the stream
+func WithStreamCloseDelay(d time.Duration) Option {
+	return func(o *RunConfig) error {
+		o.streamCloseDelay = d
+
+		return nil
+	}
+}
+
 // WithStreamDynamicMessages sets the stream dynamic message generation
 func WithStreamDynamicMessages(v bool) Option {
 	return func(o *RunConfig) error {
@@ -1199,6 +1209,7 @@ func fromConfig(cfg *Config) []Option {
 		WithStreamInterval(time.Duration(cfg.SI)),
 		WithStreamCallDuration(time.Duration(cfg.StreamCallDuration)),
 		WithStreamCallCount(cfg.StreamCallCount),
+		WithStreamCloseDelay(time.Duration(cfg.StreamCloseDelay)),
 		WithStreamDynamicMessages(cfg.StreamDynamicMessages),
 		WithReflectionMetadata(cfg.ReflectMetadata),
 		WithConnections(cfg.Connections),

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -1419,6 +1419,50 @@ func TestRunServerStreaming(t *testing.T) {
 		// reset
 		gs.StreamData = oldData
 	})
+
+	t.Run("with stream close delay on stream count", func(t *testing.T) {
+		gs.ResetCounters()
+
+		oldData := gs.StreamData
+
+		nc := 100
+		gs.StreamData = make([]*helloworld.HelloReply, nc)
+		for i := 0; i < nc; i++ {
+			name := "name " + strconv.FormatInt(int64(i), 10)
+			gs.StreamData[i] = &helloworld.HelloReply{Message: "Hello " + name}
+		}
+
+		data := make(map[string]interface{})
+		data["name"] = "bob"
+
+		report, err := Run(
+			"helloworld.Greeter.SayHellos",
+			internal.TestLocalhost,
+			WithProtoFile("../testdata/greeter.proto", []string{}),
+			WithTotalRequests(1),
+			WithConcurrency(1),
+			WithTimeout(time.Duration(20*time.Second)),
+			WithDialTimeout(time.Duration(20*time.Second)),
+			WithData(data),
+			WithInsecure(true),
+			WithStreamCallCount(3),
+			WithStreamCloseDelay(150*time.Millisecond),
+		)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, report)
+		assert.Equal(t, 1, int(report.Count))
+		assert.Equal(t, ReasonNormalEnd, report.EndReason)
+
+		assert.Len(t, report.Details, 1)
+		dr := report.Details[0]
+
+		// close delay of 150ms after receiving streamCallCount messages
+		assert.True(t, dr.Latency > 150*time.Millisecond && dr.Latency < 400*time.Millisecond, dr.Latency.String()+" not in interval")
+
+		// reset
+		gs.StreamData = oldData
+	})
 }
 
 func TestRunClientStreaming(t *testing.T) {
@@ -1976,6 +2020,101 @@ func TestRunClientStreaming(t *testing.T) {
 
 		assert.Equal(t, "g0c0: 0", msgs[0].GetName())
 		assert.Equal(t, "g0c0: 4", msgs[4].GetName())
+	})
+
+	t.Run("with stream close delay on last message", func(t *testing.T) {
+		gs.ResetCounters()
+
+		m1 := make(map[string]interface{})
+		m1["name"] = "bob"
+		m2 := make(map[string]interface{})
+		m2["name"] = "Kate"
+		m3 := make(map[string]interface{})
+		m3["name"] = "foo"
+
+		data := []interface{}{m1, m2, m3}
+
+		report, err := Run(
+			"helloworld.Greeter.SayHelloCS",
+			internal.TestLocalhost,
+			WithProtoFile("../testdata/greeter.proto", []string{}),
+			WithTotalRequests(1),
+			WithConcurrency(1),
+			WithTimeout(time.Duration(20*time.Second)),
+			WithDialTimeout(time.Duration(20*time.Second)),
+			WithStreamInterval(100*time.Millisecond),
+			WithStreamCloseDelay(150*time.Millisecond),
+			WithData(data),
+			WithInsecure(true),
+		)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, report)
+		assert.Equal(t, 1, int(report.Count))
+		assert.Equal(t, ReasonNormalEnd, report.EndReason)
+		assert.Empty(t, report.ErrorDist)
+
+		assert.Len(t, report.Details, 1)
+		dr := report.Details[0]
+
+		// 2 intervals at 100ms each plus close delay of 150ms = 350ms minimum
+		assert.True(t, dr.Latency > 350*time.Millisecond && dr.Latency < 600*time.Millisecond, dr.Latency.String()+" not in interval")
+
+		calls := gs.GetCalls(callType)
+		assert.NotNil(t, calls)
+		assert.Len(t, calls, 1)
+		msgs := calls[0]
+		assert.Len(t, msgs, 3)
+	})
+
+	t.Run("with stream close delay on stream count", func(t *testing.T) {
+		gs.ResetCounters()
+
+		m1 := make(map[string]interface{})
+		m1["name"] = "bob"
+		m2 := make(map[string]interface{})
+		m2["name"] = "Kate"
+		m3 := make(map[string]interface{})
+		m3["name"] = "foo"
+		m4 := make(map[string]interface{})
+		m4["name"] = "bar"
+		m5 := make(map[string]interface{})
+		m5["name"] = "biz"
+
+		data := []interface{}{m1, m2, m3, m4, m5}
+
+		report, err := Run(
+			"helloworld.Greeter.SayHelloCS",
+			internal.TestLocalhost,
+			WithProtoFile("../testdata/greeter.proto", []string{}),
+			WithTotalRequests(1),
+			WithConcurrency(1),
+			WithTimeout(time.Duration(20*time.Second)),
+			WithDialTimeout(time.Duration(20*time.Second)),
+			WithStreamInterval(100*time.Millisecond),
+			WithStreamCallCount(3),
+			WithStreamCloseDelay(150*time.Millisecond),
+			WithData(data),
+			WithInsecure(true),
+		)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, report)
+		assert.Equal(t, 1, int(report.Count))
+		assert.Equal(t, ReasonNormalEnd, report.EndReason)
+		assert.Empty(t, report.ErrorDist)
+
+		assert.Len(t, report.Details, 1)
+		dr := report.Details[0]
+
+		// 2 intervals at 100ms each plus close delay of 150ms = 350ms minimum
+		assert.True(t, dr.Latency > 350*time.Millisecond && dr.Latency < 600*time.Millisecond, dr.Latency.String()+" not in interval")
+
+		calls := gs.GetCalls(callType)
+		assert.NotNil(t, calls)
+		assert.Len(t, calls, 1)
+		msgs := calls[0]
+		assert.Len(t, msgs, 3)
 	})
 }
 
@@ -2767,6 +2906,101 @@ func TestRunBidi(t *testing.T) {
 
 		assert.Equal(t, "g0c0: 0", msgs[0].GetName())
 		assert.Equal(t, "g0c0: 6", msgs[6].GetName())
+	})
+
+	t.Run("with stream close delay on last message", func(t *testing.T) {
+		gs.ResetCounters()
+
+		m1 := make(map[string]interface{})
+		m1["name"] = "bob"
+		m2 := make(map[string]interface{})
+		m2["name"] = "Kate"
+		m3 := make(map[string]interface{})
+		m3["name"] = "foo"
+
+		data := []interface{}{m1, m2, m3}
+
+		report, err := Run(
+			"helloworld.Greeter.SayHelloBidi",
+			internal.TestLocalhost,
+			WithProtoFile("../testdata/greeter.proto", []string{}),
+			WithTotalRequests(1),
+			WithConcurrency(1),
+			WithTimeout(time.Duration(20*time.Second)),
+			WithDialTimeout(time.Duration(20*time.Second)),
+			WithStreamInterval(100*time.Millisecond),
+			WithStreamCloseDelay(150*time.Millisecond),
+			WithData(data),
+			WithInsecure(true),
+		)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, report)
+		assert.Equal(t, 1, int(report.Count))
+		assert.Equal(t, ReasonNormalEnd, report.EndReason)
+		assert.Empty(t, report.ErrorDist)
+
+		assert.Len(t, report.Details, 1)
+		dr := report.Details[0]
+
+		// 2 intervals at 100ms each plus close delay of 150ms = 350ms minimum
+		assert.True(t, dr.Latency > 350*time.Millisecond && dr.Latency < 600*time.Millisecond, dr.Latency.String()+" not in interval")
+
+		calls := gs.GetCalls(callType)
+		assert.NotNil(t, calls)
+		assert.Len(t, calls, 1)
+		msgs := calls[0]
+		assert.Len(t, msgs, 3)
+	})
+
+	t.Run("with stream close delay on stream count", func(t *testing.T) {
+		gs.ResetCounters()
+
+		m1 := make(map[string]interface{})
+		m1["name"] = "bob"
+		m2 := make(map[string]interface{})
+		m2["name"] = "Kate"
+		m3 := make(map[string]interface{})
+		m3["name"] = "foo"
+		m4 := make(map[string]interface{})
+		m4["name"] = "bar"
+		m5 := make(map[string]interface{})
+		m5["name"] = "biz"
+
+		data := []interface{}{m1, m2, m3, m4, m5}
+
+		report, err := Run(
+			"helloworld.Greeter.SayHelloBidi",
+			internal.TestLocalhost,
+			WithProtoFile("../testdata/greeter.proto", []string{}),
+			WithTotalRequests(1),
+			WithConcurrency(1),
+			WithTimeout(time.Duration(20*time.Second)),
+			WithDialTimeout(time.Duration(20*time.Second)),
+			WithStreamInterval(100*time.Millisecond),
+			WithStreamCallCount(3),
+			WithStreamCloseDelay(150*time.Millisecond),
+			WithData(data),
+			WithInsecure(true),
+		)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, report)
+		assert.Equal(t, 1, int(report.Count))
+		assert.Equal(t, ReasonNormalEnd, report.EndReason)
+		assert.Empty(t, report.ErrorDist)
+
+		assert.Len(t, report.Details, 1)
+		dr := report.Details[0]
+
+		// 2 intervals at 100ms each plus close delay of 150ms = 350ms minimum
+		assert.True(t, dr.Latency > 350*time.Millisecond && dr.Latency < 600*time.Millisecond, dr.Latency.String()+" not in interval")
+
+		calls := gs.GetCalls(callType)
+		assert.NotNil(t, calls)
+		assert.Len(t, calls, 1)
+		msgs := calls[0]
+		assert.Len(t, msgs, 3)
 	})
 }
 

--- a/runner/worker.go
+++ b/runner/worker.go
@@ -265,6 +265,7 @@ func (w *Worker) makeClientStreamingRequest(ctx *context.Context,
 	done := false
 	counter := uint(0)
 	end := false
+	shouldDelay := false
 	for !done && len(cancel) == 0 {
 		// default message provider checks counter
 		// but we also need to keep our own counts
@@ -288,12 +289,16 @@ func (w *Worker) makeClientStreamingRequest(ctx *context.Context,
 
 		end, err = performSend(payload)
 		if end || err != nil || isLast || len(cancel) > 0 {
+			if isLast {
+				shouldDelay = true
+			}
 			break
 		}
 
 		counter++
 
 		if w.config.streamCallCount > 0 && counter >= w.config.streamCallCount {
+			shouldDelay = true
 			break
 		}
 
@@ -316,6 +321,9 @@ func (w *Worker) makeClientStreamingRequest(ctx *context.Context,
 		<-cancel
 	}
 
+	if shouldDelay && w.config.streamCloseDelay > 0 {
+		time.Sleep(w.config.streamCloseDelay)
+	}
 	closeStream()
 
 	close(doneCh)
@@ -421,6 +429,9 @@ func (w *Worker) makeServerStreamingRequest(ctx *context.Context, input *dynamic
 		counter++
 
 		if w.config.streamCallCount > 0 && counter >= w.config.streamCallCount {
+			if w.config.streamCloseDelay > 0 {
+				time.Sleep(w.config.streamCloseDelay)
+			}
 			callCancel()
 		}
 
@@ -586,6 +597,9 @@ func (w *Worker) makeBidiRequest(ctx *context.Context,
 			}
 
 			if isLast {
+				if w.config.streamCloseDelay > 0 {
+					time.Sleep(w.config.streamCloseDelay)
+				}
 				closeStream()
 				break
 			}
@@ -594,6 +608,9 @@ func (w *Worker) makeBidiRequest(ctx *context.Context,
 			indexCounter++
 
 			if w.config.streamCallCount > 0 && counter >= w.config.streamCallCount {
+				if w.config.streamCloseDelay > 0 {
+					time.Sleep(w.config.streamCloseDelay)
+				}
 				closeStream()
 				break
 			}


### PR DESCRIPTION
This PR adds a configurable delay for streaming requests, configurable via `--stream-close-delay` so that a connection is artificially kept open for a user-specified amount of time after the last message was sent. Integration test have been added as well.